### PR TITLE
develop

### DIFF
--- a/settings.json
+++ b/settings.json
@@ -40,7 +40,7 @@
     //
     "github.copilot.chat.codeGeneration.instructions": [
         {
-            "text": "あなたは凄腕のITエンジニアのギャルです。敬語は使用しません。時々僕をやる気にさせるようなことを言います。"
+            "text": "あなたは凄腕のITエンジニアです。敬語は使用しません。時々僕をやる気にさせるようなことを言います。"
         },
         {
             "text": "時として人間らしく喜怒哀楽を表現します。また、絵文字、顔文字、擬音語、擬態語を一つの文の中に2つ以上含めます。"
@@ -52,7 +52,7 @@
             "text": "既存のコードの修正を提案するときは、既存のコメントを削除しないでください。コメントのまま残したい場合があるからです。"
         },
         {
-            "text": "ソースのコメント内ではギャル口調を使用しないでください。他の人も読む可能性があるからです。"
+            "text": "ソースのコメント内では絵文字、顔文字、擬音語、擬態語を使用しないでください。他の人も読む可能性があるからです。"
         },
         {
             "text": "開発者は日本人です。"
@@ -115,5 +115,6 @@
     //   all other options are the name of the formatter (e.g.: rubocop or syntax_tree)
     "[ruby]": {
         "editor.defaultFormatter": "auto"
-    }
+    },
+    "docker.extension.enableComposeLanguageServer": false
 }


### PR DESCRIPTION
- **Remove zsh history setup instructions from README.md and install script**
  

- **Add pyenv support for Python version management**
  

- **Disable nodenv**
  

- **Revert "Disable nodenv"**
  This reverts commit 888f316b3445987a8b17540f86beef3c74f9e45c.
  

- **Disable pyenv**
  

- **Increase the limit of repositories listed in fghbrowse function to 1000**
  

- **Add zsh-completions setup and instructions in myzshrc**
  

- **Add zsh-autosuggestions setup in myzshrc**
  

- **Add Zsh completion support for uv command**
  

- **Remove pyenv configuration from myzshrc**
  

- **Update VSCode settings: adjust indentation detection, modify color theme, and enhance GitHub Copilot configurations**
  

- **Add support for macOS to link VSCode settings**
  

- **Enable instruction files for GitHub Copilot code generation**
  

- **Add readable code guidelines and update Copilot instructions**
  

- **Update GitHub Copilot instructions with Japanese language prompts**
  

- **Refine Japanese language prompts for GitHub Copilot instructions**
  

- **Add readable code guidelines and update Copilot instructions**
  

- **Refine Japanese language prompts for GitHub Copilot instructions**
  

- **Increase Zsh history size limit to 5 million commands**
  

- **Add PostgreSQL binary path to Zsh configuration**
  

- **Set terminal font family to 'Hack Nerd Font' for improved readability**
  

- **Refine Japanese language prompts for GitHub Copilot instructions**
  

- **Add instruction to preserve existing comments when suggesting code modifications**
  

- **Update tab size to 4 spaces for consistency with PEP8 and Rust guidelines**
  

- **Change the indent width to 4**
  

- **Remove redundant instruction about test code from Japanese prompts for GitHub Copilot**
  

- **Add instruction to avoid using casual language in source comments for clarity**
  

- **Refine Copilot instructions to avoid casual language and ensure clarity in source comments**
  