### PR TITLE
Improve Docker build config and project settings

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,28 +1,14 @@
-# Git
-.git
-.gitignore
-.gitmodules
+# Whitelist: only include files needed for Docker build
+*
 
-# Git submodules (Dockerfile内で別途cloneする)
-config/zsh/plugins/zsh-autosuggestions
-config/zsh/plugins/fast-syntax-highlighting
+# Required by: COPY docker-entrypoint.sh /usr/local/bin/
+!docker-entrypoint.sh
 
-# Claude Code (exclude entire directory)
-# Note: .claude/CLAUDE.md is a symlink pointing to config/claude-code/CLAUDE.md,
-#       so the actual file will be copied to the Docker image
-.claude/
+# Required by: COPY . /home/${user_name}/dotfiles + RUN install.sh
+!install.sh
+!config/
 
-# ドキュメント
-docs/
-*.md
-!prompts/*.md
-LICENSE
-
-# IDE
-.vscode/
-
-# macOS
-.DS_Store
-
-# その他
-*.log
+# Exclude generated/runtime files within config/
+# (install.sh clones plugins fresh; completion symlinks are created at runtime)
+config/zsh/plugins/
+config/zsh/completion/

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,3 @@
+[Dockerfile]
+indent_style = space
+indent_size = 4

--- a/.gitignore
+++ b/.gitignore
@@ -1,10 +1,11 @@
-config/zsh/completion/_docker
-config/zsh/completion/_docker-compose
-# Zsh plugins (installed by install.sh)
-config/zsh/plugins/
 .claude/chrome/
 .claude/mcp-needs-auth-cache.json
 .claude/plugins/
 .claude/sessions/
 .claude/shell-snapshots/
 .claude/tasks/
+
+config/zsh/completion/_docker
+config/zsh/completion/_docker-compose
+# Zsh plugins (installed by install.sh)
+config/zsh/plugins/

--- a/.gitignore
+++ b/.gitignore
@@ -5,5 +5,6 @@ config/zsh/plugins/
 .claude/chrome/
 .claude/mcp-needs-auth-cache.json
 .claude/plugins/
+.claude/sessions/
 .claude/shell-snapshots/
 .claude/tasks/

--- a/Dockerfile
+++ b/Dockerfile
@@ -65,19 +65,19 @@ ENV TZ="$TZ"
 # Git
 #
 RUN apt-get update -qq && \
-  apt-get install -y -qq --no-install-recommends \
-    ca-certificates=20230311+deb12u1 \
-    git=1:2.39.5-0+deb12u3 && \
-  apt-get clean && \
-  rm -rf /var/lib/apt/lists/*
+    apt-get install -y -qq --no-install-recommends \
+        ca-certificates=20230311+deb12u1 \
+        git=1:2.39.5-0+deb12u3 && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
 
 #
 # clone features
 #
 RUN cd /usr/src && \
-  git clone ${features_repository} && \
-  cd features && \
-  git checkout ${features_commit}
+    git clone ${features_repository} && \
+    cd features && \
+    git checkout ${features_commit}
 
 #
 # Add user and install common utils.
@@ -86,34 +86,34 @@ RUN cd /usr/src && \
 #   https://github.com/uraitakahito/features/blob/deb6cf416fda206b99c7b771e9caa12e6952f9c7/src/common-utils/main.sh#L35-L78
 #
 RUN USERNAME=${user_name} \
-  USERUID=${user_id} \
-  USERGID=${group_id} \
-  CONFIGUREZSHASDEFAULTSHELL=true \
-  UPGRADEPACKAGES=false \
-  # When using ssh-agent inside Docker, add the user to the root group
-  # to ensure permission to access the mounted socket.
-  #   https://github.com/uraitakahito/features/blob/59e8acea74ff0accd5c2c6f98ede1191a9e3b2aa/src/common-utils/main.sh#L467-L471
-  ADDUSERTOROOTGROUP=true \
-    /usr/src/features/src/common-utils/install.sh
+    USERUID=${user_id} \
+    USERGID=${group_id} \
+    CONFIGUREZSHASDEFAULTSHELL=true \
+    UPGRADEPACKAGES=false \
+    # When using ssh-agent inside Docker, add the user to the root group
+    # to ensure permission to access the mounted socket.
+    #   https://github.com/uraitakahito/features/blob/59e8acea74ff0accd5c2c6f98ede1191a9e3b2aa/src/common-utils/main.sh#L467-L471
+    ADDUSERTOROOTGROUP=true \
+        /usr/src/features/src/common-utils/install.sh
 
 #
 # Install extra utils.
 #
 RUN cd /usr/src && \
-  git clone ${extra_utils_repository} && \
-  cd extra-utils && \
-  git checkout ${extra_utils_commit} && \
-  ADDEZA=true \
-  ADDGRPCURL=true \
-  ADDHADOLINT=true \
-  ADDMAKE=true \
-  \
-  ADDCLAUDECODE=true \
-  # Claude Code is installed under $HOME, so the username must be specified.
-  USERNAME=${user_name} \
-  \
-  UPGRADEPACKAGES=false \
-    /usr/src/extra-utils/utils/install.sh
+    git clone ${extra_utils_repository} && \
+    cd extra-utils && \
+    git checkout ${extra_utils_commit} && \
+    ADDEZA=true \
+    ADDGRPCURL=true \
+    ADDHADOLINT=true \
+    ADDMAKE=true \
+    \
+    ADDCLAUDECODE=true \
+    # Claude Code is installed under $HOME, so the username must be specified.
+    USERNAME=${user_name} \
+    \
+    UPGRADEPACKAGES=false \
+        /usr/src/extra-utils/utils/install.sh
 
 COPY docker-entrypoint.sh /usr/local/bin/
 

--- a/config/Code/User/settings.json
+++ b/config/Code/User/settings.json
@@ -112,10 +112,6 @@
 
     "terminal.integrated.scrollback": 100000,
 
-    // Let you modify the colors.
-    // "workbench.colorTheme": "Default Dark+",
-    "workbench.colorTheme": "Default Dark Modern",
-
     // https://code.visualstudio.com/updates/v1_83#_pinned-editor-tabs-on-separate-row
     "workbench.editor.pinnedTabsOnSeparateRow": true,
 


### PR DESCRIPTION
## Summary

- Switch `.dockerignore` to whitelist format, fixing a bug where `*.md` pattern excluded `config/claude-code/CLAUDE.md` and `guidelines/*.md` from the Docker build context
- Refactor Dockerfile indentation for consistency and add `.editorconfig` for Dockerfile
- Reorder `.gitignore` entries and add `.claude/sessions/` exclusion
- Remove unused color theme settings from VS Code config

## Test plan

- [x] Docker image builds successfully with the new `.dockerignore`
- [x] Verified `CLAUDE.md` and `guidelines/*.md` are present inside the container (previously missing)
- [x] Verified unwanted files (`.git`, `.github`, `.claude`, `.DS_Store`) are excluded
- [x] Verified all symlinks created by `install.sh` work correctly
- [x] Hadolint CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)