### PR TITLE
Add VS Code file nesting and integrated browser settings

### DIFF
--- a/config/Code/User/settings.json
+++ b/config/Code/User/settings.json
@@ -167,5 +167,20 @@
         "https://json.schemastore.org/": true,
         "https://json-schema.org/": true,
         "https://biomejs.dev": true
+    },
+
+    //
+    // File Nesting
+    //
+    "explorer.fileNesting.enabled": true,
+    "explorer.fileNesting.patterns": {
+        "*.ts": "${capture}.js, ${capture}.typegen.ts",
+        "*.js": "${capture}.js.map, ${capture}.min.js, ${capture}.d.ts",
+        "*.jsx": "${capture}.js",
+        "*.tsx": "${capture}.ts, ${capture}.typegen.ts",
+        "tsconfig.json": "tsconfig.*.json",
+        "package.json": "package-lock.json, yarn.lock, pnpm-lock.yaml, bun.lockb, bun.lock",
+        "*.mts": "${capture}.typegen.ts",
+        "*.cts": "${capture}.typegen.ts"
     }
 }

--- a/config/Code/User/settings.json
+++ b/config/Code/User/settings.json
@@ -182,5 +182,31 @@
         "package.json": "package-lock.json, yarn.lock, pnpm-lock.yaml, bun.lockb, bun.lock",
         "*.mts": "${capture}.typegen.ts",
         "*.cts": "${capture}.typegen.ts"
-    }
+    },
+
+    //
+    // Integrated Browser
+    // https://code.visualstudio.com/docs/debugtest/integrated-browser
+    //
+
+    // Open localhost URLs in the integrated browser instead of the system browser
+    "workbench.browser.openLocalhostLinks": true,
+
+    // Show the globe button in the title bar
+    "workbench.browser.showInTitleBar": true,
+
+    // Enable browser tools for Copilot agent
+    "workbench.browser.enableChatTools": true,
+
+    // Session data storage: "global", "workspace", or "ephemeral"
+    "workbench.browser.dataStorage": "workspace",
+
+    // Include CSS styles when sending elements to chat
+    "chat.sendElementsToChat.attachCSS": true,
+
+    // Include screenshots when sending elements to chat
+    "chat.sendElementsToChat.attachImages": true,
+
+    // Use the integrated browser for Live Preview
+    "livePreview.useIntegratedBrowser": true
 }


### PR DESCRIPTION
## Summary
- Add file nesting settings to group related files in the explorer (e.g., `.js.map` under `.js`, `package-lock.json` under `package.json`)
- Add integrated browser settings for VS Code (localhost links, title bar button, Copilot browser tools, session storage, Live Preview)

## Test plan
- [ ] Open VS Code and verify file nesting works in the explorer
- [ ] Confirm the integrated browser opens for localhost URLs
- [ ] Check that the globe button appears in the title bar

🤖 Generated with [Claude Code](https://claude.com/claude-code)