### PR TITLE
Add npm cooldown config to reject freshly published versions

### DIFF
--- a/config/npm/npmrc
+++ b/config/npm/npmrc
@@ -1,0 +1,4 @@
+# Reject package versions published within this many days (cooldown window).
+# Unit: days (Number). Requires npm CLI 11.10.0 or later.
+# https://docs.npmjs.com/cli/v11/using-npm/config#min-release-age
+min-release-age=2

--- a/install.sh
+++ b/install.sh
@@ -120,6 +120,14 @@ mkdir -p ~/.docker
 ln -fs "$SCRIPT_DIR/config/docker/config.json" ~/.docker/config.json
 
 #
+# npm
+#
+# npm does NOT natively support $XDG_CONFIG_HOME/npm/npmrc.
+# Link to the traditional ~/.npmrc location.
+#
+ln -fs "$SCRIPT_DIR/config/npm/npmrc" ~/.npmrc
+
+#
 # Debug log
 #
 mkdir -p ~/.log


### PR DESCRIPTION
Configure min-release-age=2 in a new config/npm/npmrc and symlink it
to ~/.npmrc in install.sh. This rejects any npm package version
published within the last 2 days, mitigating supply-chain attacks
that depend on the first 24-48 hours after a malicious publish.

Requires npm CLI 11.10.0 or later.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
