### PR TITLE
Configure Claude Code notification channels for iTerm2 and mobile push

### DIFF
--- a/config/claude-code/settings.json
+++ b/config/claude-code/settings.json
@@ -52,5 +52,19 @@
         ]
       }
     ]
-  }
+  },
+  "// preferredNotifChannel": [
+    "iTerm2側で以下を有効化する必要がある:",
+    "1. iTerm2 → Settings → Profiles → Terminal",
+    "2. 'Notification Center Alerts' をチェック",
+    "3. 'Filter Alerts' をクリックして 'Send escape sequence-generated alerts' を有効化"
+  ],
+  "preferredNotifChannel": "iterm2",
+  "// agentPushNotifEnabled": [
+    "Remote Controlセッション (--remote-control起動) 中に、Claudeモバイルアプリへプッシュ通知を送る:",
+    "- トリガー: タスク完了時 / 判断要求時 / '/notify me when ...' 指示時",
+    "- 必要: モバイルアプリ + claude.aiログイン (Pro以上)",
+    "- 対話中に '/config' の 'Push when Claude decides' トグルで切替可能"
+  ],
+  "agentPushNotifEnabled": true
 }


### PR DESCRIPTION
## Summary
- `preferredNotifChannel: "iterm2"` を追加し、iTerm2 のエスケープシーケンス通知経由で macOS デスクトップ通知を出す
- `agentPushNotifEnabled: true` を追加し、Remote Control セッション中に Claude モバイルアプリへプッシュ通知を送る
- 各設定の直前に `"// <key>"` 形式のキーで前提条件・トリガー・切替方法をドキュメント化 (Stack Overflow 14221781 で紹介された npm 流の JSON コメント慣例)

## Test plan
- [ ] `python3 -m json.tool ~/.claude/settings.json` でパースが通ることを確認
- [ ] iTerm2 起動 → Settings → Profiles → Terminal で "Notification Center Alerts" と "Send escape sequence-generated alerts" が有効化済みか確認
- [ ] ローカルで `claude` を起動し、長時間タスク完了時に macOS 通知センターに通知が表示されること
- [ ] `ccm` (= `claude --remote-control`) で起動し、Claude モバイルアプリにプッシュ通知が届くこと
- [ ] 既存の `Notification` フック (`ntfy.sh`) が引き続き動作すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)