### PR TITLE
Update gitignore and disable AWS Toolkit telemetry

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.claude/.last-cleanup
 .claude/chrome/
 .claude/mcp-needs-auth-cache.json
 .claude/plugins/

--- a/config/Code/User/settings.json
+++ b/config/Code/User/settings.json
@@ -208,5 +208,11 @@
     "chat.sendElementsToChat.attachImages": true,
 
     // Use the integrated browser for Live Preview
-    "livePreview.useIntegratedBrowser": true
+    "livePreview.useIntegratedBrowser": true,
+
+    //
+    // AWS Toolkit Extension
+    //
+    "aws.telemetry": false,
+    "aws.cloudformation.telemetry.enabled": false
 }

--- a/config/claude-code/settings.json
+++ b/config/claude-code/settings.json
@@ -1,4 +1,8 @@
 {
+  "//": [
+    "Discussion on how to write comments in package.json:",
+    "https://stackoverflow.com/questions/14221579/how-do-i-add-comments-to-package-json-for-npm-install"
+  ],
   "permissions": {
     "allow": [
       "Bash(chmod:*)",


### PR DESCRIPTION
## Summary
- `.claude/.last-cleanup` を `.gitignore` に追加（Claude Code が生成するキャッシュ系ファイル）
- Claude Code `settings.json` 冒頭に JSON コメントスタイルに関する stackoverflow 参照リンクを追加
- VS Code `settings.json` で AWS Toolkit Extension のテレメトリ送信を無効化（`aws.telemetry`, `aws.cloudformation.telemetry.enabled`）

## Test plan
- [ ] `git check-ignore .claude/.last-cleanup` が成功すること
- [ ] VS Code 再起動後、AWS Toolkit Extension がテレメトリを送らないこと
- [ ] Claude Code 起動時に `settings.json` の読み込みでエラーが出ないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)