### PR TITLE
Integrate pnpm config; normalize Claude Code settings key order

### DIFF
--- a/config/claude-code/settings.json
+++ b/config/claude-code/settings.json
@@ -1,8 +1,4 @@
 {
-  "//": [
-    "Discussion on how to write comments in package.json:",
-    "https://stackoverflow.com/questions/14221579/how-do-i-add-comments-to-package-json-for-npm-install"
-  ],
   "permissions": {
     "allow": [
       "Bash(chmod:*)",
@@ -57,30 +53,34 @@
       }
     ]
   },
+  "statusLine": {
+    "type": "command",
+    "command": "~/.claude/statusline.sh",
+    "padding": 1,
+    "refreshInterval": 30
+  },
+  "preferredNotifChannel": "iterm2",
+  "agentPushNotifEnabled": true,
+  "//": [
+    "Discussion on how to write comments in package.json:",
+    "https://stackoverflow.com/questions/14221579/how-do-i-add-comments-to-package-json-for-npm-install"
+  ],
   "// preferredNotifChannel": [
     "iTerm2側で以下を有効化する必要がある:",
     "1. iTerm2 → Settings → Profiles → Terminal",
     "2. 'Notification Center Alerts' をチェック",
     "3. 'Filter Alerts' をクリックして 'Send escape sequence-generated alerts' を有効化"
   ],
-  "preferredNotifChannel": "iterm2",
   "// agentPushNotifEnabled": [
     "Remote Controlセッション (--remote-control起動) 中に、Claudeモバイルアプリへプッシュ通知を送る:",
     "- トリガー: タスク完了時 / 判断要求時 / '/notify me when ...' 指示時",
     "- 必要: モバイルアプリ + claude.aiログイン (Pro以上)",
     "- 対話中に '/config' の 'Push when Claude decides' トグルで切替可能"
   ],
-  "agentPushNotifEnabled": true,
   "// statusLine": [
     "ステータスラインに 5h/7d レートリミット使用率とリセット時刻を表示する。",
     "rate_limits は Pro/Max + 最初のAPI応答後にのみ stdin に渡されるため、",
     "認証前/初回応答前は --% / --:-- にフォールバックする。",
     "refreshInterval=30s はリミットウィンドウ境界をまたぐ際の更新を保証するため。"
-  ],
-  "statusLine": {
-    "type": "command",
-    "command": "~/.claude/statusline.sh",
-    "padding": 1,
-    "refreshInterval": 30
-  }
+  ]
 }

--- a/config/npm/npmrc
+++ b/config/npm/npmrc
@@ -1,4 +1,28 @@
-# Reject package versions published within this many days (cooldown window).
-# Unit: days (Number). Requires npm CLI 11.10.0 or later.
+# Shared npm + pnpm config. Both tools read this file as ~/.npmrc.
+# Unknown keys are silently ignored by each CLI.
+# Note: pnpm 9 does NOT read ~/.config/pnpm/rc; ~/.npmrc is the only rc source.
+
+# npm + pnpm: cooldown for fresh releases.
+# Unit: days (Number). Requires npm CLI 11.10+.
 # https://docs.npmjs.com/cli/v11/using-npm/config#min-release-age
 min-release-age=2
+
+# pnpm: let pnpm self-manage its own version via the project's packageManager field.
+# Prepares for Node 25, which removes the bundled Corepack.
+manage-package-manager-versions=true
+
+# pnpm: explicit default. When the lockfile satisfies package.json, perform
+# a headless install (no resolution, just symlink from the store). Otherwise
+# resolve normally and update the lockfile. NOT the same as `frozen-lockfile`,
+# which errors on a stale lockfile (auto-enabled in CI environments).
+prefer-frozen-lockfile=true
+
+# pnpm: store/state under PNPM_HOME (exported by 45-pnpm.zsh).
+# Resolves to ~/Library/pnpm/{store,state} on macOS and
+# ${XDG_DATA_HOME:-~/.local/share}/pnpm/{store,state} on Linux,
+# both matching pnpm's own defaults.
+store-dir=${PNPM_HOME}/store
+state-dir=${PNPM_HOME}/state
+
+# pnpm: cache under XDG_CACHE_HOME (fallback ~/.cache).
+cache-dir=${XDG_CACHE_HOME:-~/.cache}/pnpm

--- a/config/zsh/conf.d/45-pnpm.zsh
+++ b/config/zsh/conf.d/45-pnpm.zsh
@@ -1,0 +1,14 @@
+# pnpm — define PNPM_HOME ahead of time so `pnpm setup` is never needed
+# (`pnpm setup` would rewrite ~/.zshrc and clash with the dotfiles symlink strategy).
+# PNPM_HOME must be exported BEFORE pnpm reads ~/.config/pnpm/rc, where ${PNPM_HOME}/{store,state} are referenced.
+
+if is-darwin; then
+  export PNPM_HOME="$HOME/Library/pnpm"
+else
+  export PNPM_HOME="${XDG_DATA_HOME:-$HOME/.local/share}/pnpm"
+fi
+path_prepend "$PNPM_HOME"
+
+if (( $+commands[pnpm] )); then
+  eval "$(pnpm completion zsh)"
+fi


### PR DESCRIPTION
## Summary
- pnpm 設定を dotfiles に統合: `config/npm/npmrc` を npm/pnpm 共有 rc に拡張し、pnpm 固有キー (`manage-package-manager-versions`, `prefer-frozen-lockfile`, `store-dir`, `state-dir`, `cache-dir`) を同居 (pnpm 9 は `~/.npmrc` のみ rc として読むため)
- `config/zsh/conf.d/45-pnpm.zsh` を新規追加: `PNPM_HOME` を OS 別に先回りで export し、`pnpm setup` (`~/.zshrc` を書き換える挙動) を不要にする。pnpm 補完も登録
- Claude Code `settings.json` のキー順を Claude Code 自身が再シリアライズした正規化順に追従

## Test plan
- [ ] `bash install.sh` 後、`pnpm config list` で全キーが反映されること
- [ ] 新規 zsh で `echo \$PNPM_HOME` が macOS で `~/Library/pnpm` / Linux で `\${XDG_DATA_HOME:-~/.local/share}/pnpm` を返すこと
- [ ] `pnpm store path` が PNPM_HOME 配下を返し、既存ストアと整合すること
- [ ] `pnpm <Tab>` で補完が効くこと
- [ ] Claude Code 起動時に `settings.json` 読み込みエラーが出ないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)