### PR TITLE
Migrate pnpm config to config.yaml for pnpm 11

### DIFF
--- a/config/npm/npmrc
+++ b/config/npm/npmrc
@@ -1,28 +1,9 @@
-# Shared npm + pnpm config. Both tools read this file as ~/.npmrc.
-# Unknown keys are silently ignored by each CLI.
-# Note: pnpm 9 does NOT read ~/.config/pnpm/rc; ~/.npmrc is the only rc source.
+# ~/.npmrc — npm-only config (and auth/registry for pnpm).
+# pnpm 11 dropped reading non-auth settings from .npmrc; pnpm's non-auth
+# user-level config now lives in ~/.config/pnpm/config.yaml (YAML).
+# See: config/pnpm/config.yaml
 
-# npm + pnpm: cooldown for fresh releases.
-# Unit: days (Number). Requires npm CLI 11.10+.
+# npm: cooldown for fresh releases. Unit: days. Requires npm CLI 11.10+.
+# pnpm's equivalent is `minimumReleaseAge` (minutes) in ~/.config/pnpm/config.yaml.
 # https://docs.npmjs.com/cli/v11/using-npm/config#min-release-age
 min-release-age=2
-
-# pnpm: let pnpm self-manage its own version via the project's packageManager field.
-# Prepares for Node 25, which removes the bundled Corepack.
-manage-package-manager-versions=true
-
-# pnpm: explicit default. When the lockfile satisfies package.json, perform
-# a headless install (no resolution, just symlink from the store). Otherwise
-# resolve normally and update the lockfile. NOT the same as `frozen-lockfile`,
-# which errors on a stale lockfile (auto-enabled in CI environments).
-prefer-frozen-lockfile=true
-
-# pnpm: store/state under PNPM_HOME (exported by 45-pnpm.zsh).
-# Resolves to ~/Library/pnpm/{store,state} on macOS and
-# ${XDG_DATA_HOME:-~/.local/share}/pnpm/{store,state} on Linux,
-# both matching pnpm's own defaults.
-store-dir=${PNPM_HOME}/store
-state-dir=${PNPM_HOME}/state
-
-# pnpm: cache under XDG_CACHE_HOME (fallback ~/.cache).
-cache-dir=${XDG_CACHE_HOME:-~/.cache}/pnpm

--- a/config/pnpm/config.yaml
+++ b/config/pnpm/config.yaml
@@ -1,0 +1,26 @@
+# pnpm 11 user-level config.
+# pnpm reads this from $XDG_CONFIG_HOME/pnpm/config.yaml
+# (= ~/.config/pnpm/config.yaml on macOS/Linux).
+# https://pnpm.io/settings
+#
+# pnpm 11 dropped reading non-auth/registry settings from .npmrc, so all
+# non-auth user-level config has to live here (YAML, camelCase).
+# Auth and registry credentials stay in ~/.npmrc.
+# Per-project overrides go in each project's pnpm-workspace.yaml.
+#
+# storeDir / stateDir / cacheDir are intentionally omitted; pnpm 11 defaults
+# already resolve to $PNPM_HOME/{store,state} and $XDG_CACHE_HOME/pnpm,
+# which is exactly what this dotfiles wants.
+
+# Cooldown for fresh releases. Unit: minutes (2880 = 2 days).
+# npm's equivalent is `min-release-age` (days) in ~/.npmrc.
+minimumReleaseAge: 2880
+
+# Let pnpm self-manage its own version via package.json's packageManager field.
+# Prepares for Node 25, which removes the bundled Corepack.
+managePackageManagerVersions: true
+
+# When the lockfile satisfies package.json, perform a headless install
+# (no resolution, just symlink from the store). NOT the same as
+# `frozen-lockfile`, which errors on a stale lockfile (auto-enabled in CI).
+preferFrozenLockfile: true

--- a/config/zsh/conf.d/45-pnpm.zsh
+++ b/config/zsh/conf.d/45-pnpm.zsh
@@ -1,13 +1,15 @@
-# pnpm — define PNPM_HOME ahead of time so `pnpm setup` is never needed
-# (`pnpm setup` would rewrite ~/.zshrc and clash with the dotfiles symlink strategy).
-# PNPM_HOME must be exported BEFORE pnpm reads ~/.config/pnpm/rc, where ${PNPM_HOME}/{store,state} are referenced.
+# pnpm — replicate `pnpm setup` declaratively. `pnpm setup` itself would
+# edit ~/.zshrc and clash with the dotfiles symlink strategy.
+#
+# Layout note: pnpm 10 moved global bins from $PNPM_HOME (flat) to
+# $PNPM_HOME/bin/. We put the latter on PATH.
 
 if is-darwin; then
   export PNPM_HOME="$HOME/Library/pnpm"
 else
   export PNPM_HOME="${XDG_DATA_HOME:-$HOME/.local/share}/pnpm"
 fi
-path_prepend "$PNPM_HOME"
+path_prepend "$PNPM_HOME/bin"
 
 if (( $+commands[pnpm] )); then
   eval "$(pnpm completion zsh)"

--- a/install.sh
+++ b/install.sh
@@ -129,6 +129,17 @@ ln -fs "$SCRIPT_DIR/config/docker/config.json" ~/.docker/config.json
 ln -fs "$SCRIPT_DIR/config/npm/npmrc" ~/.npmrc
 
 #
+# pnpm
+#
+# pnpm 11 reads user-level config from $XDG_CONFIG_HOME/pnpm/config.yaml
+# (YAML, camelCase). pnpm 11 also dropped reading non-auth settings from
+# .npmrc, so all non-auth global config lives in this file.
+# Per-project policy should live in each project's pnpm-workspace.yaml.
+#
+mkdir -p ~/.config/pnpm
+ln -fs "$SCRIPT_DIR/config/pnpm/config.yaml" ~/.config/pnpm/config.yaml
+
+#
 # Debug log
 #
 mkdir -p ~/.log


### PR DESCRIPTION
## Summary
- Fix pnpm 10+ global bin PATH: `path_prepend "$PNPM_HOME/bin"` (was `$PNPM_HOME`)
- Move pnpm non-auth config to `~/.config/pnpm/config.yaml` (YAML, camelCase); pnpm 11 no longer reads these from `.npmrc`
- Reduce `config/npm/npmrc` to npm-only (`min-release-age=2`)

## Background
pnpm 11 introduced two breaking changes that affected this dotfiles:

1. **Global bin layout**: pnpm 10+ moved global bins from `$PNPM_HOME` (flat) to `$PNPM_HOME/bin/`. `path_prepend "$PNPM_HOME"` no longer covers it, so `pnpm install -g` / `pnpm link --global` produced unreachable binaries.
2. **`.npmrc` scope shrank**: pnpm 11 only reads auth/registry from `.npmrc`. Settings like `minimumReleaseAge`, `managePackageManagerVersions`, `preferFrozenLockfile` must live in `pnpm-workspace.yaml` (per-project) or `~/.config/pnpm/config.yaml` (user-level, YAML, camelCase).

Discovered while `pnpm --filter @waxlens/core link --global` failed downstream: `pnpm bin -g` reported "The configured global bin directory ... is not in PATH".

## Test plan
- [ ] Run `./install.sh`; confirm `~/.config/pnpm/config.yaml` symlink points to `dotfiles/config/pnpm/config.yaml`
- [ ] In a new shell, `pnpm bin -g` returns `$PNPM_HOME/bin` without error
- [ ] `echo \$PATH | tr ':' '\n' | grep pnpm` includes `\$PNPM_HOME/bin`
- [ ] `pnpm install` in a project with a recently-published dependency is blocked by `minimumReleaseAge`
- [ ] `pnpm --filter @waxlens/core link --global` succeeds in waxlens (original use case)

## Prerequisites
Requires pnpm 11+. If `pnpm --version` still returns 9.x even after `corepack enable`, run `corepack prepare pnpm@latest --activate` to override corepack 0.34.7's embedded default.