### PR TITLE
Centralize .claude/* ignore rules under config/git/ignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,11 +1,3 @@
-.claude/.last-cleanup
-.claude/chrome/
-.claude/mcp-needs-auth-cache.json
-.claude/plugins/
-.claude/sessions/
-.claude/shell-snapshots/
-.claude/tasks/
-
 config/zsh/completion/_docker
 config/zsh/completion/_docker-compose
 # Zsh plugins (installed by install.sh)

--- a/config/git/ignore
+++ b/config/git/ignore
@@ -13,17 +13,30 @@
 # Claude Code sets git to ignore .claude/settings.local.json on creation.
 # https://docs.anthropic.com/ja/docs/claude-code/settings
 #
-**/.claude/cache/
-**/.claude/paste-cache/
-**/.claude/settings.local.json
+**/.claude/.last-cleanup
 **/.claude/.update.lock
+**/.claude/backups/
+**/.claude/cache/
+**/.claude/chrome/
+**/.claude/daemon.log
+**/.claude/daemon/
 **/.claude/debug/
+**/.claude/downloads/
 **/.claude/file-history/
 **/.claude/history.jsonl
 **/.claude/ide/
+**/.claude/jobs/
+**/.claude/mcp-needs-auth-cache.json
+**/.claude/paste-cache/
+**/.claude/plans/
+**/.claude/plugins/
 **/.claude/projects/
+**/.claude/session-env/
+**/.claude/sessions/
+**/.claude/settings.local.json
+**/.claude/shell-snapshots/
 **/.claude/stats-cache.json
 **/.claude/statsig/
+**/.claude/tasks/
 **/.claude/todos/
-**/.claude/plans/
-**/.claude/backups/
+**/.claude/worktrees/


### PR DESCRIPTION
## Summary
- Move all `.claude/*` ignore rules from the repository `.gitignore` to the user-global `config/git/ignore` (→ `~/.config/git/ignore` via install.sh symlink). The repo `.gitignore` now carries only rules for this dotfiles repo's own generated artifacts (zsh plugin clones, dynamic Docker completion symlinks).
- Add `daemon/`, `daemon.log`, `downloads/`, `jobs/`, `session-env/`, `worktrees/` to the user-global ignore — these are surfaced by Claude Code under `~/.claude/` and were previously not ignored anywhere.

## Test plan
- [ ] `git -c core.excludesfile=config/git/ignore check-ignore -v .claude/daemon/ .claude/worktrees/` returns matching rules
- [ ] After `./install.sh`, `git status` in the dotfiles repo shows no `.claude/*` paths under Untracked files
- [ ] `config/zsh/plugins/` still matches the repository `.gitignore`

🤖 Generated with [Claude Code](https://claude.com/claude-code)