### PR TITLE
Allow git -C add/commit in Claude Code settings

### DIFF
--- a/config/claude-code/settings.json
+++ b/config/claude-code/settings.json
@@ -4,6 +4,8 @@
       "Bash(chmod:*)",
       "Bash(diff:*)",
       "Bash(find:*)",
+      "Bash(git -C * add:*)",
+      "Bash(git -C * commit:*)",
       "Bash(git check-ignore:*)",
       "Bash(grep:*)",
       "Bash(ls:*)",


### PR DESCRIPTION
## Summary
- Claude Code の許可コマンド一覧に `Bash(git -C * add:*)` と `Bash(git -C * commit:*)` を追加
- `git -C <dir>` 形式の git add/commit を別ディレクトリ（例: worktree）で実行する際の許可プロンプトを抑止
- 既存の deny ルール (`Bash(git push origin main:*)` / `origin master:*`) は `git -C` 形式の push にはマッチしない点に留意

## Test plan
- [ ] Claude Code セッション内で `git -C /path/to/repo add <file>` が許可プロンプトなしで実行できることを確認
- [ ] 同様に `git -C /path/to/repo commit -m "..."` が許可プロンプトなしで実行できることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)