### PR TITLE
Skip dangerous mode permission prompt in Claude Code

### DIFF
--- a/config/claude-code/settings.json
+++ b/config/claude-code/settings.json
@@ -55,6 +55,7 @@
       }
     ]
   },
+  "skipDangerousModePermissionPrompt": true,
   "statusLine": {
     "type": "command",
     "command": "~/.claude/statusline.sh",


### PR DESCRIPTION
## Summary
- `config/claude-code/settings.json` に `"skipDangerousModePermissionPrompt": true` を追加
- `--dangerously-skip-permissions` 起動時に表示される確認プロンプトを抑止する
- `ccms` エイリアス (`claude --model opus --effort max --remote-control --dangerously-skip-permissions`) 起動時の摩擦を軽減
- 配置位置: `hooks` と `statusLine` の間（他のトップレベル設定キーと同階層）

## Test plan
- [ ] `ccms` 起動時に dangerous-mode の確認プロンプトが表示されないことを確認
- [ ] `ccm` (dangerous-mode 無し) は従来通り動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)