### PR TITLE
Allow cat with credential-file deny rules in Claude Code settings

### DIFF
--- a/config/claude-code/settings.json
+++ b/config/claude-code/settings.json
@@ -1,6 +1,7 @@
 {
   "permissions": {
     "allow": [
+      "Bash(cat:*)",
       "Bash(chmod:*)",
       "Bash(diff:*)",
       "Bash(find:*)",
@@ -33,7 +34,14 @@
       "Read(.env.*)",
       "Read(id_ed25519.*)",
       "Read(id_rsa.*)",
-      "Write(.env*)"
+      "Write(.env*)",
+      "Bash(cat *.env*:*)",
+      "Bash(cat *id_rsa*:*)",
+      "Bash(cat *id_ed25519*:*)",
+      "Bash(cat */.ssh/*:*)",
+      "Bash(cat *KEY*:*)",
+      "Bash(cat *API*:*)",
+      "Bash(cat *passwd*:*)"
     ]
   },
   "hooks": {


### PR DESCRIPTION
## Summary
- `Bash(cat:*)` を allow に追加し、`git commit -m "$(cat <<'EOF' ... EOF)"` 形式のヒアドキュメントコミットメッセージを許可プロンプトなしで実行可能にする
- `cat` の広い権限を補完するため、認証情報を含みがちなファイルへの `cat` を deny に追加:
  - `Bash(cat *.env*:*)` — 環境変数ファイル
  - `Bash(cat *id_rsa*:*)` / `Bash(cat *id_ed25519*:*)` — SSH 秘密鍵
  - `Bash(cat */.ssh/*:*)` — SSH ディレクトリ全般
  - `Bash(cat *KEY*:*)` — `*KEY*` を含むファイル（例: `API_KEY.txt`, `PRIVATE_KEY.pem`）
  - `Bash(cat *API*:*)` — `*API*` を含むファイル
  - `Bash(cat *passwd*:*)` — passwd ファイル（`/etc/passwd` 等）

## 背景
既存 deny の `Read(.env.*)` / `Read(id_rsa.*)` 等は `Read` ツール経由のみに効き、`Bash(cat ...)` 経由のアクセスは塞げなかった。`cat` を allow するにあたり、同等の保護を Bash 側にも追加する。

## 大文字 / 小文字の判断
`KEY` / `API` は **大文字のみ**。

- 秘密情報の命名慣習は大文字 (`API_KEY`, `SECRET_KEY`)
- 小文字 `*key*` / `*api*` だと `keyboard.json` / `api.ts` 等の通常ソースまでブロックされる
- `passwd` は Unix 慣習に従い小文字のみ

## Test plan
- [ ] `git commit -m "$(cat <<'EOF' ... EOF)"` 形式が許可プロンプトなしで実行できることを確認
- [ ] `cat ~/.ssh/id_rsa` が deny されることを確認
- [ ] `cat .env` が deny されることを確認
- [ ] `cat /etc/passwd` が deny されることを確認
- [ ] `cat MY_API_KEY.txt` が deny されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)