### PR TITLE
Document inputNeededNotifEnabled in Claude Code settings

### DIFF
--- a/config/claude-code/settings.json
+++ b/config/claude-code/settings.json
@@ -138,6 +138,13 @@
     "- 必要: モバイルアプリ + claude.aiログイン (Pro以上)",
     "- 対話中に '/config' の 'Push when Claude decides' トグルで切替可能"
   ],
+  "// inputNeededNotifEnabled": [
+    "Claudeが入力待ち (permission prompt や質問) になったときに、Claudeモバイルアプリへプッシュ通知を送る:",
+    "- 公式説明 (内部スキーマ): 'Push to mobile when a permission prompt or question is waiting'",
+    "- agentPushNotifEnabled (Claudeの能動的な通知) と対をなし、こちらは『ユーザーの入力待ち』が発火条件",
+    "- 必要: モバイルアプリ + claude.aiログイン (Pro以上)",
+    "- 対話中に '/config' の 'Push when actions required' トグルで切替可能"
+  ],
   "// statusLine": [
     "ステータスラインに 5h/7d レートリミット使用率とリセット時刻を表示する。",
     "rate_limits は Pro/Max + 最初のAPI応答後にのみ stdin に渡されるため、",


### PR DESCRIPTION
## Summary
- Add inline `// inputNeededNotifEnabled` comment matching the existing `// agentPushNotifEnabled` style
- Source: Claude Code v2.1.142 内部 Zod スキーマの describe() と /config UI ラベル
- describe(): `"Push to mobile when a permission prompt or question is waiting"`
- UI label: `Push when actions required`

## Test plan
- [ ] settings.json が valid JSON のまま (jq で確認済み)
- [ ] Claude Code 再起動後、設定読み込みエラーが出ない

🤖 Generated with [Claude Code](https://claude.com/claude-code)