### PR TITLE
Allow curl with auth/upload/non-GET deny rules in Claude Code settings

### DIFF
--- a/config/claude-code/settings.json
+++ b/config/claude-code/settings.json
@@ -15,6 +15,7 @@
       "Bash(aws-vault list:*)",
       "Bash(cat:*)",
       "Bash(chmod:*)",
+      "Bash(curl:*)",
       "Bash(diff:*)",
       "Bash(docker build:*)",
       "Bash(docker compose:*)",
@@ -127,7 +128,23 @@
       "Bash(xxd */.ssh/*:*)",
       "Bash(xxd *KEY*:*)",
       "Bash(xxd *API*:*)",
-      "Bash(xxd *passwd*:*)"
+      "Bash(xxd *passwd*:*)",
+      "Bash(curl * -u *:*)",
+      "Bash(curl * --user *:*)",
+      "Bash(curl * -H Authorization*:*)",
+      "Bash(curl * --header Authorization*:*)",
+      "Bash(curl * -d *:*)",
+      "Bash(curl * --data*:*)",
+      "Bash(curl * -F *:*)",
+      "Bash(curl * --form*:*)",
+      "Bash(curl * -T *:*)",
+      "Bash(curl * --upload-file*:*)",
+      "Bash(curl * -X POST*:*)",
+      "Bash(curl * -X PUT*:*)",
+      "Bash(curl * -X DELETE*:*)",
+      "Bash(curl * --request POST*:*)",
+      "Bash(curl * --request PUT*:*)",
+      "Bash(curl * --request DELETE*:*)"
     ]
   },
   "hooks": {


### PR DESCRIPTION
## Summary
- Add `Bash(curl:*)` to allow list
- Add 16 deny entries blocking auth-bearing (`-u`, `-H Authorization`), data-sending (`-d`, `--data`, `-F`, `--form`, `-T`, `--upload-file`), and non-GET HTTP methods (`-X POST/PUT/DELETE`)
- Same multi-layer defense philosophy as the existing `cat *.env*` and `git add *.env*` deny rules

## Test plan
- [ ] `curl -sL https://example.com` がプロンプトなしで通る
- [ ] `curl -fsSL https://...` (install スクリプト形式) も通る
- [ ] `curl -u user:pass https://...` がプロンプトを要求する
- [ ] `curl -H "Authorization: Bearer ..." https://...` がプロンプトを要求する
- [ ] `curl -d "..." https://...` / `curl -X POST https://...` がプロンプトを要求する

🤖 Generated with [Claude Code](https://claude.com/claude-code)