### PR TITLE
Add global gitleaks pre-commit hook (silent when absent)

### DIFF
--- a/config/git/config
+++ b/config/git/config
@@ -1,3 +1,6 @@
 [core]
 	# Display non-ASCII characters (e.g., Japanese) as-is instead of octal escapes
 	quotepath = false
+	# Use dotfiles-managed global hooks (e.g. gitleaks pre-commit).
+	# Note: this overrides each repository's .git/hooks/* entirely.
+	hooksPath = ~/.config/git/hooks

--- a/config/git/hooks/pre-commit
+++ b/config/git/hooks/pre-commit
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+#
+# Global pre-commit hook for the dotfiles.
+# Runs gitleaks on staged changes; bypass with `git commit --no-verify`.
+#
+# Silent no-op when gitleaks is not installed, because dotfiles must
+# work on environments where gitleaks is not provisioned (Dev Container,
+# fresh VMs, CI runners, etc).
+set -eu
+
+command -v gitleaks >/dev/null 2>&1 || exit 0
+
+if ! gitleaks git --staged --pre-commit --redact -v; then
+  echo "" >&2
+  echo "gitleaks detected potential secrets in staged changes." >&2
+  echo "Review the findings above. To bypass intentionally:" >&2
+  echo "  git commit --no-verify" >&2
+  exit 1
+fi

--- a/install.sh
+++ b/install.sh
@@ -38,6 +38,16 @@ ln -fs "$SCRIPT_DIR/config/git/config" ~/.config/git/config
 ln -fs "$SCRIPT_DIR/config/git/ignore" ~/.config/git/ignore
 
 #
+# Global git hooks (gitleaks pre-commit)
+#
+# core.hooksPath = ~/.config/git/hooks (set in config/git/config)
+# The hook itself is a silent no-op when gitleaks is not installed,
+# so it is safe to symlink on every environment.
+#
+mkdir -p ~/.config/git/hooks
+ln -fs "$SCRIPT_DIR/config/git/hooks/pre-commit" ~/.config/git/hooks/pre-commit
+
+#
 # VS Code
 #
 if is-docker; then


### PR DESCRIPTION
## Summary
- Set `core.hooksPath = ~/.config/git/hooks` in `config/git/config`
- Add `config/git/hooks/pre-commit` running `gitleaks git --staged --pre-commit --redact -v`
- Hook is a **silent no-op** when gitleaks is not installed, so dotfiles works unchanged on Dev Container / CI / fresh VM environments where gitleaks is not provisioned
- Update `install.sh` to symlink the hook into `~/.config/git/hooks/`

## Behavior

| Scenario | Result |
|---|---|
| gitleaks 未インストール | 何も表示せず exit 0 (silent no-op) |
| gitleaks ありで secret なし | gitleaks ログ + 通常 commit |
| gitleaks ありで secret あり | commit ブロック + `--no-verify` 案内 |

Bypass: `git commit --no-verify`

## Side Effect

Setting `core.hooksPath` **overrides each repository's `.git/hooks/*` entirely**. Repository-local hooks under `.git/hooks/` will no longer execute. This is intentional for unified per-user enforcement.

## Test plan
- [x] `install.sh` 再実行で symlink 作成 / `core.hooksPath` 反映
- [x] gitleaks 不在環境（サブシェルで `PATH` 制限）→ 無音、exit 0
- [x] secret なし → 通常コミット成功
- [x] secret あり（github-pat 形式）→ exit 1、警告表示、commit ブロック
- [x] `~` 展開: `git config --path --get core.hooksPath` で絶対パスに解決
- [x] このコミット自体で hook が動作（"no leaks found" で通過）

🤖 Generated with [Claude Code](https://claude.com/claude-code)