### PR TITLE
Bump uraitakahito/features pin to 2.0.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -43,8 +43,8 @@
 #
 #   sudo chown -R $(id -u):$(id -g) /zsh-volume
 
-# Debian 12.13
-FROM debian:bookworm-20260406
+# Debian 12.14
+FROM debian:bookworm-20260518
 
 ARG user_name=developer
 ARG user_id

--- a/Dockerfile
+++ b/Dockerfile
@@ -49,9 +49,9 @@ FROM debian:bookworm-20260518
 ARG user_name=developer
 ARG user_id
 ARG group_id
-# https://github.com/uraitakahito/features/releases/tag/1.0.0
+# https://github.com/uraitakahito/features/releases/tag/2.0.1
 ARG features_repository="https://github.com/uraitakahito/features.git"
-ARG features_commit="e8d887d2e17e79f5289b0e8a087dd0730dcad24e"
+ARG features_commit="9f7e672e27207f374d56e5da7f862b0b5b110b3f"
 # https://github.com/uraitakahito/extra-utils/releases/tag/1.1.0
 ARG extra_utils_repository="https://github.com/uraitakahito/extra-utils.git"
 ARG extra_utils_commit="2c5b1ab72c7b98b2a9c42c084aa6b67cdaa36625"


### PR DESCRIPTION
## Summary
- Bump `features_commit` from `e8d887d2...` (1.0.0) to `9f7e672e...` (**2.0.1**)
- Upstream changes:
  - **2.0.0**: Alpine Linux support dropped (no impact — this dotfiles is Debian bookworm)
  - **2.0.1**: common-utils 2.6.1 (bubblewrap RHEL fix), Ubuntu 26.04 resolute support added to docker-outside-of-docker
- The fork's `ADDUSERTOROOTGROUP` option remains compatible (verified via regression check)

## Test plan
- [x] image rebuilds successfully
- [x] developer user exists and is in root group (`id` shows `0(root)`)
- [x] `/bin/zsh` is the default shell
- [x] dotfiles symlinks installed (e.g. `~/.config/git/config -> dotfiles/config/git/config`)
- [x] claude, eza, git all functional via zsh login shell
- [x] No regression versus pre-bump behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)