### PR TITLE
Enable Docker outside of Docker (DooD) via host socket mount

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,9 +22,20 @@
 #
 #   docker volume create $PROJECT-zsh-history
 #
-# Start the Docker container(/run/host-services/ssh-auth.sock is a virtual socket provided by Docker Desktop for Mac and OrbStack.):
+# Start the Docker container (DooD enabled — see SOCKETPATH below):
+# - /run/host-services/ssh-auth.sock is a virtual socket provided by Docker
+#   Desktop for Mac and OrbStack.
+# - /var/run/docker.sock is bind-mounted to /var/run/docker-host.sock inside the
+#   container; the docker-outside-of-docker feature's docker-init.sh script
+#   forwards it to /var/run/docker.sock at runtime (GID sync or socat proxy).
 #
-#   docker container run -d --rm --init -v /run/host-services/ssh-auth.sock:/agent.sock -e SSH_AUTH_SOCK=/agent.sock -e GH_TOKEN=$(gh auth token) --mount type=bind,src=`pwd`,dst=/app --mount type=volume,source=$PROJECT-zsh-history,target=/zsh-volume --name $PROJECT-container $PROJECT-image
+#   docker container run -d --rm --init -v /run/host-services/ssh-auth.sock:/agent.sock -e SSH_AUTH_SOCK=/agent.sock -v /var/run/docker.sock:/var/run/docker-host.sock -e GH_TOKEN=$(gh auth token) --mount type=bind,src=`pwd`,dst=/app --mount type=volume,source=$PROJECT-zsh-history,target=/zsh-volume --name $PROJECT-container $PROJECT-image
+#
+# Windows users: run the above command from a **WSL2 shell** with Docker
+# Desktop's "Enable integration with my default WSL distro" turned on. The
+# container expects /var/run/docker.sock to be a unix socket; PowerShell-native
+# invocation would pass the named-pipe path (//./pipe/docker_engine) which is
+# incompatible.
 #
 # Log into the container.
 #
@@ -114,6 +125,33 @@ RUN cd /usr/src && \
     \
     UPGRADEPACKAGES=false \
         /usr/src/extra-utils/utils/install.sh
+
+#
+# Install docker-outside-of-docker (uses host's docker daemon via socket mount)
+# https://github.com/uraitakahito/features/tree/2.0.1/src/docker-outside-of-docker
+#
+# Version pins (consistent with the dotfiles' philosophy of pinning everything):
+#   VERSION=29.4.3        # moby-cli package version (Microsoft Moby repo)
+#   MOBYBUILDXVERSION=0.33.0  # moby-buildx package version (Microsoft Moby repo)
+#   DOCKERDASHCOMPOSEVERSION=v2  # Compose major version (enum: none|latest|v1|v2)
+#
+# Note: VERSION / MOBYBUILDXVERSION here track the moby-cli / moby-buildx
+# package versions in https://packages.microsoft.com/ (NOT the docker/cli or
+# docker/buildx upstream GitHub tag versions, which differ).
+#
+# SOCKETPATH is set explicitly (matches the default) to make the socket path
+# visible in the Dockerfile. The container expects the host's docker socket to
+# be mounted at this path at runtime; see the run command in the header comment.
+#
+RUN VERSION=29.4.3 \
+    MOBY=true \
+    MOBYBUILDXVERSION=0.33.0 \
+    DOCKERDASHCOMPOSEVERSION=v2 \
+    INSTALLDOCKERBUILDX=true \
+    INSTALLDOCKERCOMPOSESWITCH=false \
+    SOCKETPATH=/var/run/docker-host.sock \
+    USERNAME=${user_name} \
+        /usr/src/features/src/docker-outside-of-docker/install.sh
 
 COPY docker-entrypoint.sh /usr/local/bin/
 

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -11,7 +11,14 @@ _is_sourced() {
 }
 
 _main() {
-    exec "$@"
+	# If the docker-outside-of-docker feature is installed, delegate to its
+	# init script. docker-init.sh syncs the docker group GID with the mounted
+	# host socket (or falls back to a socat proxy when GID sync isn't viable)
+	# and then `exec "$@"` to start the container's CMD.
+	if [ -x /usr/local/share/docker-init.sh ]; then
+		exec /usr/local/share/docker-init.sh "$@"
+	fi
+	exec "$@"
 }
 
 # If we are sourced from elsewhere, don't perform any further actions

--- a/install.sh
+++ b/install.sh
@@ -127,8 +127,14 @@ ln -fs "$SCRIPT_DIR/config/gemini/settings.json" ~/.config/gemini/settings.json
 #
 # Docker
 #
-mkdir -p ~/.docker
-ln -fs "$SCRIPT_DIR/config/docker/config.json" ~/.docker/config.json
+# Only link on macOS host: config.json sets `currentContext = "orbstack"` which
+# only exists on the host. In a Docker container (DooD via socket mount), this
+# config would break `docker version` etc. with "context not found".
+#
+if is-darwin && ! is-docker; then
+  mkdir -p ~/.docker
+  ln -fs "$SCRIPT_DIR/config/docker/config.json" ~/.docker/config.json
+fi
 
 #
 # npm


### PR DESCRIPTION
## Summary

Installs the **`docker-outside-of-docker`** feature from `uraitakahito/features` 2.0.1, giving the dev container a Docker CLI (Moby), `docker compose` v2, and buildx that all talk to the **host's docker daemon** through a bind-mounted socket. This adds nested docker capability without running a second daemon (no `--privileged` required, host image cache is shared).

## What changed

### Dockerfile
- New `RUN` step invoking `docker-outside-of-docker/install.sh`
- Version pins (Microsoft Moby package versions — distinct from `docker/cli` and `docker/buildx` upstream tags):
  - `VERSION=29.4.3` (moby-cli)
  - `MOBYBUILDXVERSION=0.33.0` (moby-buildx)
  - `DOCKERDASHCOMPOSEVERSION=v2` (Compose major-version pin; enum allows none/latest/v1/v2)
  - `INSTALLDOCKERBUILDX=true`, `INSTALLDOCKERCOMPOSESWITCH=false`
  - `SOCKETPATH=/var/run/docker-host.sock` (set explicitly to keep the path visible)
- Header comment: updated the start-container command example to add `-v /var/run/docker.sock:/var/run/docker-host.sock` and document that Windows users must launch from a WSL2 shell (named-pipe vs unix-socket incompatibility)

### docker-entrypoint.sh
- Delegates to `/usr/local/share/docker-init.sh` when present. The init script syncs the docker group GID with the mounted socket (or falls back to a `socat` proxy when GID sync isn't viable) before `exec "$@"`

### install.sh
- The Docker `config.json` symlink is now gated to **macOS host only** (`is-darwin && ! is-docker`). The host config sets `currentContext = "orbstack"` which doesn't exist inside the container; without this gate `docker version` fails with "context not found"

## Test plan
- [x] image rebuilds cleanly (Dockerfile + 2 entrypoint changes)
- [x] `docker --version` / `docker compose version` / `docker buildx version` work
- [x] `docker version` talks to host daemon (containerd 2.2.2, runc 1.4.2)
- [x] `docker ps` sees host-side containers including this one (DooD evidence)
- [x] `docker run --rm hello-world` succeeds (nested run executes on host daemon)
- [x] developer user is added to docker group (gid 999)
- [x] existing features unaffected: developer user, root group, zsh default, claude-code, eza, git, dotfiles symlinks

## Side notes
- WSL2 must be used on Windows (named-pipe vs unix-socket)
- `INSTALLDOCKERCOMPOSESWITCH=false` follows the upstream 1.10.0 default (was `true` in 1.8.0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)