### PR TITLE
Make --remote-control opt-in via ccmr/ccmrs aliases

### DIFF
--- a/config/zsh/conf.d/10-aliases.zsh
+++ b/config/zsh/conf.d/10-aliases.zsh
@@ -36,5 +36,7 @@ fi
 # One important detail: low, medium, and high persist across sessions. Set it once and it sticks until you change it. max resets when your session ends.
 #   https://kentgigger.com/posts/claude-code-effort-parameter
 #
-alias ccm="claude --model opus --effort max --remote-control"
-alias ccms="claude --model opus --effort max --remote-control --dangerously-skip-permissions"
+alias ccm="claude --model opus --effort max"
+alias ccms="claude --model opus --effort max --dangerously-skip-permissions"
+alias ccmr="claude --model opus --effort max --remote-control"
+alias ccmrs="claude --model opus --effort max --remote-control --dangerously-skip-permissions"


### PR DESCRIPTION
## Summary
- `ccm` / `ccms` から `--remote-control` を除去し、デフォルトを安全側 (リモートコントロールなし) に変更
- 既存挙動は新設の `ccmr` / `ccmrs` で復活させ、リモコンが許容される環境でのみ意識的にopt-inする運用に切替

## Why
職場マシンのセキュリティポリシーで `--remote-control` が許容されないため、`ccm` を打って事故るリスクを排除するのが目的。職場では `ccm` / `ccms`、自宅などポリシーが許す環境では `ccmr` / `ccmrs` を使う。

## Test plan
- [x] `zsh -n config/zsh/conf.d/10-aliases.zsh` でシンタックスチェック
- [x] 対話シェルで `alias ccm ccms ccmr ccmrs` を実行し、4本とも期待通りに展開されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)