### PR TITLE
Refresh Claude Code hooks and install.sh sweep

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,1 +1,0 @@
-/Users/takahito/dotfiles/config/claude-code/CLAUDE.md

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,1 +1,0 @@
-/Users/takahito/dotfiles/config/claude-code/settings.json

--- a/.claude/statusline.sh
+++ b/.claude/statusline.sh
@@ -1,1 +1,0 @@
-/Users/takahito/dotfiles/config/claude-code/statusline.sh

--- a/config/claude-code/hooks/notify.sh
+++ b/config/claude-code/hooks/notify.sh
@@ -3,16 +3,20 @@
 # Claude Code hook notification wrapper for ntfy.sh.
 #
 # Usage:
-#   ~/.claude/hooks/notify.sh <event>   # event name is included in the title
+#   ~/.claude/hooks/notify.sh <event>   # Stop / Notification / ...
 #
-# Claude Code passes the hook payload (JSON) on stdin. We extract `cwd`
-# from it so the receiving device can tell which project the event came
-# from without opening the message body.
+# Reads Claude Code's hook payload (JSON) from stdin and forwards it to
+# ntfy.sh as a structured push notification.
+#
+# Behavior:
+# - Per-event Priority / Tags so Stop (completion) and Notification
+#   (input-required) are distinguishable at a glance on the receiver.
+# - Body is Markdown-formatted, including the short session id and the
+#   Claude message (when present in the payload).
 #
 # NTFY_TOPIC unset/empty is treated as "notifications disabled" rather
 # than an error, because install.sh symlinks this script on every
-# environment (Dev Containers, CI runners, etc.) regardless of whether a
-# topic is provisioned.
+# environment (Dev Containers, CI runners, etc.).
 #
 set -eu
 
@@ -22,10 +26,29 @@ event="${1:?event name required}"
 
 payload=$(cat)
 cwd=$(printf '%s' "$payload" | jq -r '.cwd // empty' 2>/dev/null || true)
+session_id=$(printf '%s' "$payload" | jq -r '.session_id // empty' 2>/dev/null | cut -c1-8 || true)
+message=$(printf '%s' "$payload" | jq -r '.message // empty' 2>/dev/null || true)
 proj=$(basename "${cwd:-?}")
+
+# Per-event Priority / Tags so receivers can distinguish event kinds.
+case "$event" in
+  Stop)         priority="default"; tags="white_check_mark,claude-code" ;;
+  Notification) priority="high";    tags="bell,claude-code" ;;
+  *)            priority="default"; tags="claude-code" ;;
+esac
+
+# Markdown body: project + short session id, plus Claude's message
+# when present (Notification events carry the permission prompt etc).
+body="**Project**: \`${proj}\`
+**Session**: \`${session_id:-?}\`"
+[ -n "$message" ] && body="${body}
+
+> ${message}"
 
 curl -fsS \
   -H "Title: Claude ${event} (${proj})" \
-  -H "Tags: claude-code" \
-  -d "${event} fired in ${cwd:-?}" \
+  -H "Priority: $priority" \
+  -H "Tags: $tags" \
+  -H "Markdown: yes" \
+  -d "$body" \
   "ntfy.sh/${NTFY_TOPIC}" >/dev/null

--- a/config/claude-code/hooks/notify.sh
+++ b/config/claude-code/hooks/notify.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+#
+# Claude Code hook notification wrapper for ntfy.sh.
+#
+# Usage:
+#   ~/.claude/hooks/notify.sh <event>   # event name is included in the title
+#
+# Claude Code passes the hook payload (JSON) on stdin. We extract `cwd`
+# from it so the receiving device can tell which project the event came
+# from without opening the message body.
+#
+# NTFY_TOPIC unset/empty is treated as "notifications disabled" rather
+# than an error, because install.sh symlinks this script on every
+# environment (Dev Containers, CI runners, etc.) regardless of whether a
+# topic is provisioned.
+#
+set -eu
+
+[ -n "${NTFY_TOPIC:-}" ] || exit 0
+
+event="${1:?event name required}"
+
+payload=$(cat)
+cwd=$(printf '%s' "$payload" | jq -r '.cwd // empty' 2>/dev/null || true)
+proj=$(basename "${cwd:-?}")
+
+curl -fsS \
+  -H "Title: Claude ${event} (${proj})" \
+  -H "Tags: claude-code" \
+  -d "${event} fired in ${cwd:-?}" \
+  "ntfy.sh/${NTFY_TOPIC}" >/dev/null

--- a/config/claude-code/settings.json
+++ b/config/claude-code/settings.json
@@ -213,22 +213,20 @@
   "hooks": {
     "Stop": [
       {
-        "matcher": "",
         "hooks": [
           {
             "type": "command",
-            "command": "curl -H \"Title: Claude Code Hook\" -d \"Stop Hookが呼ばれました\" ntfy.sh/$NTFY_TOPIC"
+            "command": "~/.claude/hooks/notify.sh Stop"
           }
         ]
       }
     ],
     "Notification": [
       {
-        "matcher": "",
         "hooks": [
           {
             "type": "command",
-            "command": "curl -H \"Title: Claude Code Hook\" -d \"Notification Hookが呼ばれました\" ntfy.sh/$NTFY_TOPIC"
+            "command": "~/.claude/hooks/notify.sh Notification"
           }
         ]
       }

--- a/config/git/ignore
+++ b/config/git/ignore
@@ -40,3 +40,12 @@
 **/.claude/tasks/
 **/.claude/todos/
 **/.claude/worktrees/
+
+#
+# Personal notes
+#
+# Repositories may contain a private-note/ directory for personal
+# scratch notes, diagrams, and references that should not be shared.
+# Globally ignored so each repo doesn't need its own .gitignore line.
+#
+**/private-note/

--- a/install.sh
+++ b/install.sh
@@ -113,10 +113,11 @@ ln -fs "$SCRIPT_DIR/config/ruff/ruff.toml" ~/.config/ruff/ruff.toml
 #
 # https://docs.anthropic.com/ja/docs/claude-code/memory
 #
-mkdir -p ~/.claude
+mkdir -p ~/.claude ~/.claude/hooks
 ln -fs "$SCRIPT_DIR/config/claude-code/settings.json" ~/.claude/settings.json
 ln -fs "$SCRIPT_DIR/config/claude-code/CLAUDE.md" ~/.claude/CLAUDE.md
 ln -fs "$SCRIPT_DIR/config/claude-code/statusline.sh" ~/.claude/statusline.sh
+ln -fs "$SCRIPT_DIR/config/claude-code/hooks/notify.sh" ~/.claude/hooks/notify.sh
 
 #
 # Gemini CLI

--- a/install.sh
+++ b/install.sh
@@ -5,6 +5,32 @@ SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd -P)
 
 source $SCRIPT_DIR/config/zsh/functions/helper.zsh
 
+#
+# Sweep stale dotfiles symlinks under known link roots.
+#
+# Any symlink whose target points back into this repo is removed, then
+# re-created by the ln -fs calls below. This lets file deletions or
+# renames in the repo be reflected on the next install.sh run.
+#
+# Scope: we restrict the walk to directories install.sh actually links
+# into. Walking the entire $HOME would trigger macOS TCC denials for
+# ~/Documents, ~/Desktop, ~/Library/Mail, etc. when invoked from iTerm.
+#
+
+# HOME 直下のドットファイル (~/.vimrc, ~/.editorconfig, ~/.npmrc)
+find "$HOME" -maxdepth 1 -type l -lname "$SCRIPT_DIR/*" -delete 2>/dev/null || true
+
+# install.sh が貼る既知の親ディレクトリ群 (TCC 非保護領域のみ)
+for dir in \
+  "$HOME/.claude" \
+  "$HOME/.config" \
+  "$HOME/.docker" \
+  "$HOME/.vscode-server" \
+  "$HOME/Library/Application Support/Code/User"
+do
+  [ -d "$dir" ] && find "$dir" -type l -lname "$SCRIPT_DIR/*" -delete 2>/dev/null || true
+done
+
 cd ~/ || exit
 
 #


### PR DESCRIPTION
## Summary
- Drop stale `.claude/{CLAUDE.md,settings.json,statusline.sh}` symlinks left over from the XDG move (`~/.claude/*` covers them via install.sh).
- Ignore `private-note/` globally via `~/.config/git/ignore` so personal scratch directories in any repo stay out of `git status`.
- Replace the duplicated inline curl commands in `settings.json` hooks with a `notify.sh` wrapper. The wrapper guards on `NTFY_TOPIC`, extracts `cwd` / `session_id` / `message` from the hook payload, and emits a Markdown-formatted body.
- Add a sweep step to `install.sh` that removes any symlink whose target points back into this repo, so deletions/renames in the repo are reflected on the next install.sh run.
- Restrict the sweep to known link roots (`$HOME` maxdepth 1 + `~/.claude`, `~/.config`, `~/.docker`, `~/.vscode-server`, `~/Library/Application Support/Code/User`) so it does not trigger macOS TCC denials from iTerm.
- Differentiate `notify.sh` per event: Stop uses default priority with a check-mark tag, Notification uses high priority with a bell tag, and the message is appended as a Markdown blockquote when present.

## Test plan
- [x] `bash -n` on install.sh and notify.sh
- [x] shellcheck on notify.sh
- [x] sweep ran end-to-end on macOS with no `Operation not permitted` errors
- [x] notify.sh traced through three scenarios (Stop / Notification with message / NTFY_TOPIC unset)
- [x] Live ntfy.sh sends succeed for both Stop and Notification events

🤖 Generated with [Claude Code](https://claude.com/claude-code)