### PR TITLE
Resolve ShellCheck SC1091 on install.sh source line

### DIFF
--- a/config/Code/User/settings.json
+++ b/config/Code/User/settings.json
@@ -214,5 +214,13 @@
     // AWS Toolkit Extension
     //
     "aws.telemetry": false,
-    "aws.cloudformation.telemetry.enabled": false
+    "aws.cloudformation.telemetry.enabled": false,
+
+    //
+    // ShellCheck Extension
+    //
+
+    // -x: follow `source` directives so SC1091 disappears when paired with
+    //     a `# shellcheck source=path` hint at the source line.
+    "shellcheck.customArgs": ["-x"]
 }

--- a/install.sh
+++ b/install.sh
@@ -3,6 +3,7 @@ set -u
 
 SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd -P)
 
+# shellcheck source=config/zsh/functions/helper.zsh
 source $SCRIPT_DIR/config/zsh/functions/helper.zsh
 
 #


### PR DESCRIPTION
## Summary

Silence the `SC1091 (Not following: …)` warning that VS Code surfaces on `install.sh:6` (the `source $SCRIPT_DIR/config/zsh/functions/helper.zsh` line) by combining two changes:

1. **`install.sh`** — add a `# shellcheck source=config/zsh/functions/helper.zsh` directive immediately above the `source` line. ShellCheck cannot expand `$SCRIPT_DIR` statically, so the directive provides the path hint.
2. **`config/Code/User/settings.json`** — add `"shellcheck.customArgs": ["-x"]` so the VS Code shellcheck extension passes `-x` (external-sources mode). Without `-x`, the directive's path hint is honored but SC1091 still fires; with `-x` ShellCheck actually follows into `helper.zsh` and the warning disappears.

As a side effect, ShellCheck now cross-analyzes `helper.zsh` from `install.sh` (cross-file linting benefit).

| | Before | After |
| --- | --- | --- |
| `shellcheck install.sh` | SC1091 + SC2086 | SC1091 + SC2086 (unchanged — `-x` is supplied by VS Code) |
| `shellcheck -x install.sh` | SC1091 + SC2086 | only SC2086 |
| VS Code editor | SC1091 wiggly underline | gone |

`SC2086` (Double quote `$SCRIPT_DIR`) on the same line is intentionally left as a separate follow-up.

## Test plan

- [x] `shellcheck -x install.sh` — `SC1091` block count is 0; only `SC2086` remains.
- [x] No new warnings originated from `helper.zsh` (`grep '^In '` shows a single block for `install.sh line 7`).
- [x] VS Code Reload Window — the SC1091 wiggle on `install.sh:7` is gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)