### PR TITLE
Quote source path in install.sh to silence ShellCheck SC2086

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -4,7 +4,7 @@ set -u
 SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd -P)
 
 # shellcheck source=config/zsh/functions/helper.zsh
-source $SCRIPT_DIR/config/zsh/functions/helper.zsh
+source "$SCRIPT_DIR/config/zsh/functions/helper.zsh"
 
 #
 # Sweep stale dotfiles symlinks under known link roots.


### PR DESCRIPTION
## Summary

Silence the `SC2086 (Double quote to prevent globbing and word splitting)` warning that ShellCheck emits on the `source` line of `install.sh` by wrapping the whole path in double quotes.

This also aligns the line with the convention already used by every `ln -fs` invocation later in the file:

| | install.sh:7 (this PR) | install.sh:42, 47, 55, … (existing) |
| --- | --- | --- |
| Form | `source "$SCRIPT_DIR/config/zsh/functions/helper.zsh"` | `ln -fs "$SCRIPT_DIR/config/..."` |

Until this PR, the `source` line was the only stylistic exception in the file.

## Test plan

- [x] `shellcheck -x install.sh` — exits 0 with no warning blocks (previously 1 block with SC2086).
- [x] `bash -n install.sh` — syntax ok.
- [x] No regression: SC1091 count remains at 0.
- [x] VS Code editor shows no warning markers on `install.sh:7`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)