### PR TITLE
Extract sweep target directories into LINK_ROOTS array

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -20,13 +20,14 @@ source "$SCRIPT_DIR/config/zsh/functions/helper.zsh"
 find "$HOME" -maxdepth 1 -type l -lname "$SCRIPT_DIR/*" -delete 2>/dev/null || true
 
 # install.sh が貼る既知の親ディレクトリ群 (TCC 非保護領域のみ)
-for dir in \
-  "$HOME/.claude" \
-  "$HOME/.config" \
-  "$HOME/.docker" \
-  "$HOME/.vscode-server" \
+LINK_ROOTS=(
+  "$HOME/.claude"
+  "$HOME/.config"
+  "$HOME/.docker"
+  "$HOME/.vscode-server"
   "$HOME/Library/Application Support/Code/User"
-do
+)
+for dir in "${LINK_ROOTS[@]}"; do
   [ -d "$dir" ] && find "$dir" -type l -lname "$SCRIPT_DIR/*" -delete 2>/dev/null || true
 done
 


### PR DESCRIPTION
## Summary

Refactor the dotfiles symlink sweep so the list of parent directories lives in a named `LINK_ROOTS` bash array, instead of being inlined into the `for dir in \ … do` header. Adding or removing a sweep target now requires editing only the array literal, and the iteration itself is one self-explanatory line.

| | Before | After |
| --- | --- | --- |
| Sweep targets | Inlined into the `for` header with line-continuation backslashes | Named array `LINK_ROOTS` |
| Loop header | `for dir in \ … do` | `for dir in "${LINK_ROOTS[@]}"; do` |
| Adding a target | Edit 2 places (insert line + adjust backslash) | Edit 1 place (add element) |

The behavior is identical — same paths, same iteration order, same `find -delete` call inside the loop.

## Test plan

- [x] `shellcheck -x install.sh` — exits 0, no new warnings.
- [x] `bash -n install.sh` — syntax ok.
- [x] Diff is restricted to the for-loop block; behavior unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)