### PR TITLE
Adopt extra-utils 1.4.0; fix notify.sh "(no message)" notifications

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -63,9 +63,9 @@ ARG group_id
 # https://github.com/uraitakahito/features/releases/tag/2.0.1
 ARG features_repository="https://github.com/uraitakahito/features.git"
 ARG features_commit="9f7e672e27207f374d56e5da7f862b0b5b110b3f"
-# https://github.com/uraitakahito/extra-utils/releases/tag/1.1.0
+# https://github.com/uraitakahito/extra-utils/releases/tag/1.4.0
 ARG extra_utils_repository="https://github.com/uraitakahito/extra-utils.git"
-ARG extra_utils_commit="2c5b1ab72c7b98b2a9c42c084aa6b67cdaa36625"
+ARG extra_utils_commit="18ed6c714f1ecf58930ced0a3d2e281cf1977994"
 
 ARG LANG=C.UTF-8
 ENV LANG="$LANG"
@@ -115,13 +115,23 @@ RUN cd /usr/src && \
     cd extra-utils && \
     git checkout ${extra_utils_commit} && \
     ADDEZA=true \
+    ADDGITLEAKS=true \
     ADDGRPCURL=true \
     ADDHADOLINT=true \
     ADDMAKE=true \
+    ADDXXD=true \
+    ADDYQ=true \
     \
     ADDCLAUDECODE=true \
     # Claude Code is installed under $HOME, so the username must be specified.
     USERNAME=${user_name} \
+    \
+    # Pin tool versions (env-overridable since extra-utils 1.3.0; consistent
+    # with this repo's philosophy of pinning everything).
+    GITLEAKSVERSION=8.30.1 \
+    GRPCURLVERSION=1.9.3 \
+    HADOLINTVERSION=2.12.0 \
+    YQVERSION=4.53.2 \
     \
     UPGRADEPACKAGES=false \
         /usr/src/extra-utils/utils/install.sh

--- a/config/claude-code/hooks/notify.sh
+++ b/config/claude-code/hooks/notify.sh
@@ -29,20 +29,46 @@ payload=$(cat)
 cwd=$(printf '%s' "$payload" | jq -r '.cwd // empty' 2>/dev/null || true)
 session_id=$(printf '%s' "$payload" | jq -r '.session_id // empty' 2>/dev/null | cut -c1-8 || true)
 message=$(printf '%s' "$payload" | jq -r '.message // empty' 2>/dev/null || true)
+transcript=$(printf '%s' "$payload" | jq -r '.transcript_path // empty' 2>/dev/null || true)
 proj=$(basename "${cwd:-?}")
 
-# Per-event Priority / Tags so receivers can distinguish event kinds.
+# Per-event priority / tags and body. Stop has no .message field, so its body
+# is derived from the transcript: last main-thread text, else last tool name,
+# else a static line — so a Stop notification is never empty "(no message)".
 case "$event" in
-  Stop)         priority="default"; tags="white_check_mark,claude-code" ;;
-  Notification) priority="high";    tags="bell,claude-code" ;;
-  *)            priority="default"; tags="claude-code" ;;
+  Notification)
+    priority="high"; tags="bell,claude-code"
+    summary="${message:-入力待ちです}" ;;
+  Stop|SubagentStop)
+    priority="default"; tags="white_check_mark,claude-code"
+    last_text=""; last_tool=""
+    if [ -n "$transcript" ] && [ -r "$transcript" ]; then
+      # idea1: last main-thread text (subagent entries excluded), 1 line, capped.
+      last_text=$(jq -r 'select(.type=="assistant" and (.isSidechain|not))
+                         | .message.content[]? | select(.type=="text") | .text' \
+                  "$transcript" 2>/dev/null | tail -1 | tr '\n' ' ' | cut -c1-180 || true)
+      # idea2 fallback: name of the last tool used, when the turn produced no text.
+      last_tool=$(jq -r 'select(.type=="assistant" and (.isSidechain|not))
+                         | .message.content[]? | select(.type=="tool_use") | .name' \
+                  "$transcript" 2>/dev/null | tail -1 || true)
+    fi
+    summary="${last_text:-${last_tool:+最後の操作: $last_tool}}"
+    summary="${summary:-セッションが完了しました}" ;;
+  *)
+    priority="default"; tags="claude-code"
+    summary="${message:-イベント: $event}" ;;
 esac
 
-# Plain text body: Claude's message + short session id.
-# Title carries project/event metadata; the body stays minimal so the
-# iOS lock screen (which does not render Markdown via APNs) is readable.
-body="${message:-(no message)}
+# Plain text body: summary + short session id. The body stays minimal/plain so
+# the iOS lock screen (which does not render Markdown via APNs) stays readable.
+body="${summary}
 (session ${session_id:-?})"
+
+# NTFY_DRYRUN set → print TITLE/body to stderr and skip sending (local testing).
+if [ -n "${NTFY_DRYRUN:-}" ]; then
+  printf 'TITLE: %s — %s\nTAGS:  %s\nBODY:\n%s\n' "$proj" "$event" "$tags" "$body" >&2
+  exit 0
+fi
 
 curl -fsS \
   -H "Title: ${proj} — ${event}" \


### PR DESCRIPTION
## Summary

develop に積まれた 2 つの独立した変更を main へ反映する。

### 1. Adopt extra-utils 1.4.0 (`50e11bb`)
- ピンを 1.1.0 (`2c5b1ab`) → 1.4.0 (`18ed6c7`) に更新。
- 新しい opt-in を有効化:
  - `ADDGITLEAKS` — 既存の休眠 pre-commit フック (`config/git/hooks/pre-commit`) を起動し、コミット時の秘密スキャンを有効化。
  - `ADDYQ` — yq (YAML プロセッサ)。
  - `ADDXXD` — xxd。bookworm では vim-common があっても `--no-install-recommends` のため xxd は引き込まれず、明示が必要（検証で判明）。
- ツール version を Dockerfile に明示ピン (gitleaks 8.30.1 / grpcurl 1.9.3 / hadolint 2.12.0 / yq 4.53.2)。
- 検証: dotfiles-image を再ビルドし全ツールの導入と version を確認。gitleaks フックが擬似シークレットを含むコミットをブロックすることを確認。

### 2. Fix "(no message)" notifications (`45e8528`)
- Stop フックの payload には `message` フィールドが無いため、notify.sh が常に "(no message)" を表示していた。
- Stop の本文を `transcript_path` から導出: 本流の最後のテキスト → 最後のツール名 → 静的文言、の多段フォールバック。
- Notification は従来どおり `.message` を使用。テスト用 `NTFY_DRYRUN` ガードを追加。
- 検証: dry-run マトリクス (Stop の text / tool-only / transcript 不読、Notification、SubagentStop でのサブエージェント除外) と shellcheck clean。

## Test plan
- `docker image build` 成功、ツールが pinned version で導入される。
- `NTFY_DRYRUN=1` で notify.sh の全イベント分岐を確認し、「(no message)」が出ないこと。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
