### PR TITLE
zsh: add fcstop/fcshell for Apple Container

### DIFF
--- a/config/zsh/conf.d/30-fzf.zsh
+++ b/config/zsh/conf.d/30-fzf.zsh
@@ -75,6 +75,26 @@ fdvscode() {
 }
 
 #
+# fcshell - Login to an Apple Container with shell
+#   usage: fcshell /bin/bash
+#
+fcshell() {
+  local cid
+  cid=$(container ls | sed 1d | fzf | awk '{print $1}')
+  [ -n "$cid" ] && container exec -it "$cid" $1
+}
+
+#
+# fcstop - Stop a running Apple Container
+#   usage: fcstop
+#
+fcstop() {
+  local cid
+  cid=$(container ls | sed 1d | fzf | awk '{print $1}')
+  [ -n "$cid" ] && container stop "$cid"
+}
+
+#
 # fghbrowse - Open the selected GitHub repository from the list in the browser.
 #   usage: fghbrowse
 #


### PR DESCRIPTION
## 概要

既存の Docker 用 fzf ヘルパー `fdstop` / `fdshell` に対応する、Apple Container（`container` CLI）版の `fcstop` / `fcshell` を追加します。

## 変更内容

`config/zsh/conf.d/30-fzf.zsh` に 2 関数を追加（`fdvscode` の直後）:

- **`fcshell`** — fzf で選んだ Apple Container にシェル接続（`container exec -it`）
- **`fcstop`** — fzf で選んだ Apple Container を停止（`container stop`）

```bash
fcshell() {
  local cid
  cid=$(container ls | sed 1d | fzf | awk '{print $1}')
  [ -n "$cid" ] && container exec -it "$cid" $1
}

fcstop() {
  local cid
  cid=$(container ls | sed 1d | fzf | awk '{print $1}')
  [ -n "$cid" ] && container stop "$cid"
}
```

## 背景・設計

- Apple Container CLI 1.0.0 は Docker と 1:1 対応:
  - `docker ps` → `container ls`
  - `docker exec -it` → `container exec -it`
  - `docker stop` → `container stop`
- 一覧出力は ID が第 1 列のため、既存ピッカー `sed 1d | fzf | awk '{print $1}'` をそのまま流用。
- 既存 fd* と同様、ファイル冒頭の `type fzf` ガード配下に配置。`container` 自体のガードは付けず、fd* のスタイル（`docker` の存在を前提）に揃えています。

## 検証

- `zsh -n config/zsh/conf.d/30-fzf.zsh`: 構文 OK
- `type fcshell fcstop`: 両方とも shell function として定義を確認
- 共有ピッカー `container ls | sed 1d | awk '{print $1}'`: ID 抽出を実出力で確認
- 使い捨て `alpine:latest` コンテナで `container exec`（exec パス）/ `container stop`（stop パス）を実機検証し、後片付けまで完了
- `-it`（TTY）対応は `container exec --help` で確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WpLgSt9kpf6MhTKFGESxxB
