### PR TITLE
pnpm: drop removed managePackageManagerVersions from global config

### DIFF
--- a/config/pnpm/config.yaml
+++ b/config/pnpm/config.yaml
@@ -16,9 +16,10 @@
 # npm's equivalent is `min-release-age` (days) in ~/.npmrc.
 minimumReleaseAge: 2880
 
-# Let pnpm self-manage its own version via package.json's packageManager field.
-# Prepares for Node 25, which removes the bundled Corepack.
-managePackageManagerVersions: true
+# pnpm self-manages its version from package.json's packageManager field
+# (prep for Node 25, which removes the bundled Corepack). In pnpm 11 this is
+# already the default (pmOnFail: download); the old managePackageManagerVersions
+# setting was removed and cannot live in the global config, so nothing is set here.
 
 # When the lockfile satisfies package.json, perform a headless install
 # (no resolution, just symlink from the store). NOT the same as


### PR DESCRIPTION
## 概要

pnpm のグローバル設定 `config/pnpm/config.yaml` から、pnpm 11 で廃止された `managePackageManagerVersions: true` を削除します。

## 背景

- `managePackageManagerVersions` は pnpm 11 で**削除**され、新設の `pmOnFail` に統合された（`packageManagerStrict(Version)` も同様）。
- さらにこのキーは**グローバル設定（`~/.config/pnpm/config.yaml`）には置けない**ため、pnpm 11.x はこれを無視し、シェルログインのたびに次の警告を出していた:
  ```
  [WARN] The following settings cannot be set in the global config file
  ... and were ignored: "managePackageManagerVersions".
  Move them to a project-level pnpm-workspace.yaml. ...
  ```

## 変更内容

- `managePackageManagerVersions: true` を削除。
- 説明コメントは消さず、「pnpm 11 では既定（`pmOnFail: download`）なので設定不要」という事実に更新。

## なぜ「削除」でよいのか

元々の狙い（`package.json` の `packageManager` 欄に従って pnpm が自分の版を自己管理 / Node 25 の Corepack 同梱廃止に備える）は、**`pmOnFail: download` が pnpm 11 の既定**であるため、行を消しても挙動は変わらない。グローバルに後継 `pmOnFail` を「置く」対応は不可（同様に無視される）と実証済み。

## 検証（pnpm 11.4.0・隔離 XDG_CONFIG_HOME）

- `managePackageManagerVersions` の警告が消えた / その他の WARN なし
- `minimumReleaseAge: 2880` と `preferFrozenLockfile: true` は引き続き有効

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WpLgSt9kpf6MhTKFGESxxB
