### PR TITLE
Enable experimental Apple Container support in VS Code

### DIFF
--- a/config/Code/User/settings.json
+++ b/config/Code/User/settings.json
@@ -119,6 +119,13 @@
     "workbench.iconTheme": "material-icon-theme",
 
     //
+    // Apple
+    //
+    // Support for the Containerization Framework on macOS
+    // https://github.com/microsoft/vscode-remote-release/issues/11012
+    "dev.containers.experimentalAppleContainerSupport": true,
+
+    //
     // Ruby LSP
     //
     // Ruby version managers


### PR DESCRIPTION
## 概要

VS Code の Dev Containers 拡張で **Apple Container（`container` CLI）への接続**を有効化する実験的設定を追加します。

## 変更内容

`config/Code/User/settings.json` に以下を追加（コメント＋上流 issue リンク付き）:

```json
"dev.containers.experimentalAppleContainerSupport": true
```

これにより、コマンドパレットの **「Dev Containers: Attach to Running Apple Container...」** で、起動中の Apple Container にアタッチして開発できるようになります（Docker の "Attach to Running Container" 相当）。

## 補足

- 実験的サポートのため、サイドバーの Containers パネル UI は依然 Docker/Podman ランタイムを要求します。回避策としてパレットコマンドを直接使用します。
- 上流トラッキング: [microsoft/vscode-remote-release#11012](https://github.com/microsoft/vscode-remote-release/issues/11012)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011JX56KyKp3yvWU4sD1Dngd
