### PR TITLE
claude-code: relocate inputNeededNotifEnabled, add tui fullscreen

### DIFF
--- a/config/claude-code/settings.json
+++ b/config/claude-code/settings.json
@@ -240,6 +240,7 @@
   },
   "skipDangerousModePermissionPrompt": true,
   "preferredNotifChannel": "iterm2",
+  "inputNeededNotifEnabled": true,
   "agentPushNotifEnabled": true,
   "//": [
     "Discussion on how to write comments in package.json:",
@@ -270,5 +271,5 @@
     "認証前/初回応答前は --% / --:-- にフォールバックする。",
     "refreshInterval=30s はリミットウィンドウ境界をまたぐ際の更新を保証するため。"
   ],
-  "inputNeededNotifEnabled": true
+  "tui": "fullscreen"
 }


### PR DESCRIPTION
## 概要

Claude Code のユーザー設定 `config/claude-code/settings.json` に 2 点の小さな調整を加えます。

## 変更内容

1. **`inputNeededNotifEnabled: true` の位置を整理**
   - 末尾に孤立していたキーを、関連する通知設定（`preferredNotifChannel` / `agentPushNotifEnabled`）の隣、既存の `// inputNeededNotifEnabled` コメントブロックの近くへ移動。
   - 値は `true` のままで **挙動の変化なし**（純粋に整理目的）。

2. **`tui: "fullscreen"` を追加**
   - TUI をフルスクリーン表示にする。本体スキーマ上の許容値は `"default" | "fullscreen"`（v2.1.186 で確認）。

## 補足

- `inputNeededNotifEnabled` は「Claude が入力待ち（許可プロンプト / 質問）になったときに Claude モバイルアプリへプッシュ通知を送る」設定で、サーバ側機能キー `code_requires_action` に対応（本体バイナリで確認）。
- 差分は 1 ファイル `config/claude-code/settings.json` のみ（+2 / -1）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WpLgSt9kpf6MhTKFGESxxB
