### PR TITLE
zsh: drop ccmrs alias (remote-control + skip-permissions combo)

### DIFF
--- a/config/zsh/conf.d/10-aliases.zsh
+++ b/config/zsh/conf.d/10-aliases.zsh
@@ -39,4 +39,3 @@ fi
 alias ccm="claude --model opus --effort max"
 alias ccms="claude --model opus --effort max --dangerously-skip-permissions"
 alias ccmr="claude --model opus --effort max --remote-control"
-alias ccmrs="claude --model opus --effort max --remote-control --dangerously-skip-permissions"


### PR DESCRIPTION
## 概要

zsh エイリアス定義から `ccmrs` を削除します。

## 変更内容

`config/zsh/conf.d/10-aliases.zsh` から次のエイリアスを削除:

```sh
alias ccmrs="claude --model opus --effort max --remote-control --dangerously-skip-permissions"
```

## 理由

`--remote-control`（リモート制御）と `--dangerously-skip-permissions`（全許可プロンプトのスキップ）を **併用** するエイリアスです。リモート制御下で全ての許可確認を飛ばすのは不必要にリスクが高い組み合わせのため、ワンキーのショートカットとしては提供しないことにします。

## 残るエイリアス（安全な部品）

- `ccmr` — リモート制御（許可プロンプトは維持）
- `ccms` — 許可スキップ（ローカルのみ）

## 確認

- リポジトリ内に `ccmrs` への他参照なし（`git grep` で確認）
- `zsh -n` 構文チェック通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WpLgSt9kpf6MhTKFGESxxB
