### PR TITLE
claude-code: honor CLAUDE_CONFIG_DIR (export from zsh, XDG default)

### DIFF
--- a/config/claude-code/hooks/notify.sh
+++ b/config/claude-code/hooks/notify.sh
@@ -3,7 +3,7 @@
 # Claude Code hook notification wrapper for ntfy.sh.
 #
 # Usage:
-#   ~/.claude/hooks/notify.sh <event>   # Stop / Notification / ...
+#   "$CLAUDE_CONFIG_DIR"/hooks/notify.sh <event>   # Stop / Notification / ... (default ~/.config/claude)
 #
 # Reads Claude Code's hook payload (JSON) from stdin and forwards it to
 # ntfy.sh as a structured push notification.

--- a/config/claude-code/settings.json
+++ b/config/claude-code/settings.json
@@ -216,7 +216,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "~/.claude/hooks/notify.sh Stop"
+            "command": "${CLAUDE_CONFIG_DIR:-${XDG_CONFIG_HOME:-$HOME/.config}/claude}/hooks/notify.sh Stop"
           }
         ]
       }
@@ -226,7 +226,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "~/.claude/hooks/notify.sh Notification"
+            "command": "${CLAUDE_CONFIG_DIR:-${XDG_CONFIG_HOME:-$HOME/.config}/claude}/hooks/notify.sh Notification"
           }
         ]
       }
@@ -234,7 +234,7 @@
   },
   "statusLine": {
     "type": "command",
-    "command": "~/.claude/statusline.sh",
+    "command": "${CLAUDE_CONFIG_DIR:-${XDG_CONFIG_HOME:-$HOME/.config}/claude}/statusline.sh",
     "padding": 1,
     "refreshInterval": 30
   },

--- a/config/zsh/conf.d/02-claude.zsh
+++ b/config/zsh/conf.d/02-claude.zsh
@@ -1,0 +1,12 @@
+# Claude Code config directory.
+#
+# CLAUDE_CONFIG_DIR is the single base dir Claude Code reads
+# (v2.1.191: process.env.CLAUDE_CONFIG_DIR ?? ~/.claude). settings.json,
+# CLAUDE.md, statusline.sh, hooks, projects (sessions) and credentials all
+# live under it.
+#
+# Honor an existing value (e.g. a Dev Container's ENV=/claude-config);
+# otherwise default to the XDG path, matching tmux/git/ruff/pnpm/gemini
+# under ~/.config. install.sh resolves the same expression so install and
+# runtime agree on the location.
+export CLAUDE_CONFIG_DIR="${CLAUDE_CONFIG_DIR:-${XDG_CONFIG_HOME:-$HOME/.config}/claude}"

--- a/install.sh
+++ b/install.sh
@@ -7,6 +7,14 @@ SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd -P)
 source "$SCRIPT_DIR/config/zsh/functions/helper.zsh"
 
 #
+# Claude Code config directory (same canonical expression as
+# config/zsh/conf.d/02-claude.zsh). Honor an existing CLAUDE_CONFIG_DIR
+# (e.g. a Dev Container's ENV=/claude-config); otherwise default to the
+# XDG path so install and runtime resolve to the same location.
+#
+CLAUDE_DIR="${CLAUDE_CONFIG_DIR:-${XDG_CONFIG_HOME:-$HOME/.config}/claude}"
+
+#
 # Sweep stale dotfiles symlinks under known link roots.
 #
 # Scope: we restrict the walk to directories install.sh actually links
@@ -21,7 +29,8 @@ find "$HOME" -maxdepth 1 -type l -lname "$SCRIPT_DIR/*" -delete 2>/dev/null || t
 
 # install.sh が貼る既知の親ディレクトリ群 (TCC 非保護領域のみ)
 LINK_ROOTS=(
-  "$HOME/.claude"
+  "$CLAUDE_DIR"        # Claude Code config dir (CLAUDE_CONFIG_DIR or XDG default)
+  "$HOME/.claude"      # legacy Claude location; sweep stale links left there
   "$HOME/.config"
   "$HOME/.docker"
   "$HOME/.vscode-server"
@@ -143,11 +152,11 @@ ln -fs "$SCRIPT_DIR/config/ruff/ruff.toml" ~/.config/ruff/ruff.toml
 #
 # https://docs.anthropic.com/ja/docs/claude-code/memory
 #
-mkdir -p ~/.claude ~/.claude/hooks
-ln -fs "$SCRIPT_DIR/config/claude-code/settings.json" ~/.claude/settings.json
-ln -fs "$SCRIPT_DIR/config/claude-code/CLAUDE.md" ~/.claude/CLAUDE.md
-ln -fs "$SCRIPT_DIR/config/claude-code/statusline.sh" ~/.claude/statusline.sh
-ln -fs "$SCRIPT_DIR/config/claude-code/hooks/notify.sh" ~/.claude/hooks/notify.sh
+mkdir -p "$CLAUDE_DIR" "$CLAUDE_DIR/hooks"
+ln -fs "$SCRIPT_DIR/config/claude-code/settings.json" "$CLAUDE_DIR/settings.json"
+ln -fs "$SCRIPT_DIR/config/claude-code/CLAUDE.md" "$CLAUDE_DIR/CLAUDE.md"
+ln -fs "$SCRIPT_DIR/config/claude-code/statusline.sh" "$CLAUDE_DIR/statusline.sh"
+ln -fs "$SCRIPT_DIR/config/claude-code/hooks/notify.sh" "$CLAUDE_DIR/hooks/notify.sh"
 
 #
 # Gemini CLI


### PR DESCRIPTION
## What

dotfiles now owns `CLAUDE_CONFIG_DIR` instead of hardcoding `~/.claude`.

- New `config/zsh/conf.d/02-claude.zsh` exports `CLAUDE_CONFIG_DIR`, respecting any
  existing value (e.g. a Dev Container's `ENV=/claude-config`) and otherwise
  defaulting to the XDG path `~/.config/claude`.
- `install.sh` resolves the same canonical expression and links Claude Code files
  (`settings.json` / `CLAUDE.md` / `statusline.sh` / `hooks/notify.sh`) into
  `$CLAUDE_DIR`; the stale-link sweep covers both the new dir and legacy `~/.claude`.
- `settings.json` hook / statusLine `command`s use the same fallback expression.
- `notify.sh` usage comment updated.

## Why

Align Claude Code's config location with the other XDG-based tools
(tmux / git / ruff / pnpm / gemini) under `~/.config`, and make a single variable
the source of truth across the interactive shell, `install.sh`, and `claude` itself.

## Verification

- `zsh -n` / `bash -n` / `shellcheck` / `jq` all pass.
- `install.sh` run on host: the 4 symlinks land in `~/.config/claude`; the current
  session runs with `CLAUDE_CONFIG_DIR=~/.config/claude`.
- Override respected: `CLAUDE_CONFIG_DIR=/claude-config` is honored.
- `git grep '~/.claude'` returns only a documentation comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
