### PR TITLE
claude-code: relocate tui fullscreen, add theme dark

### DIFF
--- a/config/claude-code/settings.json
+++ b/config/claude-code/settings.json
@@ -238,7 +238,9 @@
     "padding": 1,
     "refreshInterval": 30
   },
+  "tui": "fullscreen",
   "skipDangerousModePermissionPrompt": true,
+  "theme": "dark",
   "preferredNotifChannel": "iterm2",
   "inputNeededNotifEnabled": true,
   "agentPushNotifEnabled": true,
@@ -270,6 +272,5 @@
     "rate_limits は Pro/Max + 最初のAPI応答後にのみ stdin に渡されるため、",
     "認証前/初回応答前は --% / --:-- にフォールバックする。",
     "refreshInterval=30s はリミットウィンドウ境界をまたぐ際の更新を保証するため。"
-  ],
-  "tui": "fullscreen"
+  ]
 }


### PR DESCRIPTION
## What

- Move `"tui": "fullscreen"` out of its trailing slot (after the `//`
  comment-key documentation blocks) and up into the real-settings cluster,
  next to `skipDangerousModePermissionPrompt`.
- Add `"theme": "dark"`.

## Why

Keep the `//`-prefixed documentation comment keys grouped at the end of the
file, and pin the UI theme explicitly. Config/cosmetic only — no behavioral
logic changes. `jq` validates the result.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
