### PR TITLE
claude-code: post-mount config seeding (seed-config-dir.sh)

### DIFF
--- a/config/claude-code/seed-config-dir.sh
+++ b/config/claude-code/seed-config-dir.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+#
+# seed-config-dir.sh — symlink dotfiles' Claude Code config into $CLAUDE_CONFIG_DIR.
+#
+# Why this is separate from install.sh:
+#   The Apple `container` dev image mounts a named volume over
+#   $CLAUDE_CONFIG_DIR (=/claude-config) at RUNTIME so `claude --resume`
+#   survives `--rm`. That mount SHADOWS the symlinks install.sh creates at
+#   BUILD time. docker-entrypoint.sh calls this script AFTER the volume is
+#   mounted to re-create them. Idempotent (ln -f); safe to run on the host
+#   too (install.sh delegates here).
+#
+set -u
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd -P)
+
+#
+# Claude Code config directory (same canonical expression as install.sh and
+# config/zsh/conf.d/02-claude.zsh). Honor an existing CLAUDE_CONFIG_DIR
+# (e.g. a Dev Container's ENV=/claude-config); otherwise default to the XDG
+# path so install and runtime resolve to the same location.
+#
+CLAUDE_DIR="${CLAUDE_CONFIG_DIR:-${XDG_CONFIG_HOME:-$HOME/.config}/claude}"
+
+mkdir -p "$CLAUDE_DIR" "$CLAUDE_DIR/hooks"
+ln -fs "$SCRIPT_DIR/settings.json"   "$CLAUDE_DIR/settings.json"
+ln -fs "$SCRIPT_DIR/CLAUDE.md"       "$CLAUDE_DIR/CLAUDE.md"
+ln -fs "$SCRIPT_DIR/statusline.sh"   "$CLAUDE_DIR/statusline.sh"
+ln -fs "$SCRIPT_DIR/hooks/notify.sh" "$CLAUDE_DIR/hooks/notify.sh"

--- a/install.sh
+++ b/install.sh
@@ -152,11 +152,11 @@ ln -fs "$SCRIPT_DIR/config/ruff/ruff.toml" ~/.config/ruff/ruff.toml
 #
 # https://docs.anthropic.com/ja/docs/claude-code/memory
 #
-mkdir -p "$CLAUDE_DIR" "$CLAUDE_DIR/hooks"
-ln -fs "$SCRIPT_DIR/config/claude-code/settings.json" "$CLAUDE_DIR/settings.json"
-ln -fs "$SCRIPT_DIR/config/claude-code/CLAUDE.md" "$CLAUDE_DIR/CLAUDE.md"
-ln -fs "$SCRIPT_DIR/config/claude-code/statusline.sh" "$CLAUDE_DIR/statusline.sh"
-ln -fs "$SCRIPT_DIR/config/claude-code/hooks/notify.sh" "$CLAUDE_DIR/hooks/notify.sh"
+# Delegate to the shared seeder so build-time (host / image) and runtime
+# (docker-entrypoint.sh, after a volume is mounted over $CLAUDE_DIR) lay down
+# the same symlinks. See config/claude-code/seed-config-dir.sh.
+#
+CLAUDE_CONFIG_DIR="$CLAUDE_DIR" "$SCRIPT_DIR/config/claude-code/seed-config-dir.sh"
 
 #
 # Gemini CLI


### PR DESCRIPTION
## What

Extract `install.sh`'s Claude Code symlink block into a standalone,
idempotent seeder — `config/claude-code/seed-config-dir.sh` — and have
`install.sh` delegate to it.

## Why

The Apple `container` dev image (hello-javascript template) mounts a named
volume over `$CLAUDE_CONFIG_DIR` (`/claude-config`) at **runtime** so
`claude --resume` survives `--rm`. That mount shadows the symlinks
`install.sh` created at **build** time, hiding the custom `statusLine` /
hooks — so the container falls back to the default status line.

A standalone seeder lets `docker-entrypoint.sh` re-create the symlinks
*after* the volume is mounted. `install.sh` now delegates to the same
script, so build / host / runtime all lay down identical symlinks.

## Notes

- Host behavior is unchanged: the same four symlinks (`settings.json`,
  `CLAUDE.md`, `statusline.sh`, `hooks/notify.sh`).
- `settings.json` stays a symlink, so Claude's runtime edits remain
  git-visible (and a useful reference).

## Verification

- `bash -n` + `shellcheck` clean on the new seeder.
- `./install.sh` re-run on host: the four symlinks resolve to the dotfiles
  sources and `settings.json` still carries `statusLine`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
