### PR TITLE
container-init: single container bootstrap hook (delegated from entrypoint)

### DIFF
--- a/container-init.sh
+++ b/container-init.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+#
+# container-init.sh — set up dotfiles' container-side conventions at startup.
+#
+# Called by the dev image's docker-entrypoint.sh *after* the volumes are
+# mounted. The template's entrypoint stays generic; this script owns the
+# specifics (volume ownership, Claude Code config). Best-effort and
+# idempotent; it must never abort the container (the caller runs under set -e).
+#
+set -u
+
+HERE=$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd -P)
+
+# Make a freshly-mounted (root-owned) named volume writable by the dev user.
+# No-op if the path is empty or not a directory. Never fatal.
+_own() {
+	[ -n "${1:-}" ] && [ -d "$1" ] && sudo -n chown -R "$(id -u):$(id -g)" "$1" 2>/dev/null || true
+}
+
+# 1) Volume ownership.
+_own "${CLAUDE_CONFIG_DIR:-}"
+_own /zsh-volume
+
+# 2) Claude Code config: re-create the symlinks a mounted volume shadows.
+[ -n "${CLAUDE_CONFIG_DIR:-}" ] && "$HERE/config/claude-code/seed-config-dir.sh" || true


### PR DESCRIPTION
## What

Add `container-init.sh` at the repo root — a single container bootstrap hook
for the dev image.

## Why

The dev image (hello-javascript template) needs two things done at container
start, *after* the volumes are mounted:

- chown the freshly-mounted (root-owned) named volumes to the dev user;
- re-create the Claude Code config symlinks that a mounted volume shadows
  (via the existing `seed-config-dir.sh`).

Until now `docker-entrypoint.sh` held that logic, mixing tool-specific
knowledge into a generic entrypoint. Moving it here lets the template's
entrypoint become a thin, generic "run container-init.sh, then exec", and
keeps the convention knowledge in dotfiles — where those conventions are
defined.

## Notes

- Best-effort and idempotent; never aborts the container (`|| true`).
- No-op for paths that are not mounted (`[ -d ]` guard), so a bare run is safe.
- `install.sh` is unchanged; both it and `container-init.sh` reuse
  `seed-config-dir.sh`.

## Verification

- `bash -n` + `shellcheck` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
