### PR TITLE
feat: reserve config/mcp slot for Claude Code CLI (--mcp-config, no server yet)

### DIFF
--- a/config/mcp/README.md
+++ b/config/mcp/README.md
@@ -1,0 +1,12 @@
+# MCP (Claude Code CLI)
+
+Claude Code CLI 用の MCP サーバー定義 `mcp.json` を置くスロット。
+
+- `install.sh` が `mcp.json` を検出したら `~/.config/mcp/mcp.json` に symlink する
+  （無ければ空フォルダのまま＝リンク切れを作らない）。
+- 起動時に読み込む（中身を入れてから）:
+
+      claude --mcp-config ~/.config/mcp/mcp.json
+
+いまはスロット予約のみで `mcp.json` は未配置。サーバー（xing5 / taylorwilsdon 等）と
+認証を決めたら、その `mcp.json` をここに追加する。

--- a/install.sh
+++ b/install.sh
@@ -148,6 +148,16 @@ mkdir -p ~/.config/ruff
 ln -fs "$SCRIPT_DIR/config/ruff/ruff.toml" ~/.config/ruff/ruff.toml
 
 #
+# MCP (Claude Code CLI)
+#
+# Reserved slot. The servers file (config/mcp/mcp.json) is optional and added
+# later; symlink it only if present so an empty slot leaves no dangling link.
+# Load at runtime with: claude --mcp-config ~/.config/mcp/mcp.json
+#
+mkdir -p ~/.config/mcp
+[ -f "$SCRIPT_DIR/config/mcp/mcp.json" ] && ln -fs "$SCRIPT_DIR/config/mcp/mcp.json" ~/.config/mcp/mcp.json
+
+#
 # CLAUDE CODE
 #
 # https://docs.anthropic.com/ja/docs/claude-code/memory


### PR DESCRIPTION
## 概要
Claude Code CLI 用の MCP 設定 `mcp.json` の**置き場所だけ**を先に用意します。サーバー/認証（xing5 か taylorwilsdon 等）はまだ決めないので、**中身は入れません**。

## 変更内容
- `config/mcp/`（`.gitkeep` ＋ `README.md`）を新設（空フォルダの予約）
- `install.sh` に1ブロック追記：`mkdir ~/.config/mcp` ＋ **条件付き symlink**
  （`config/mcp/mcp.json` が**あれば**貼る。無ければ空フォルダのまま＝リンク切れを作らない）

## なぜ条件付きか
いまは `mcp.json` が無いので無条件 `ln -fs` だと dangling symlink ができてしまう。`[ -f … ] &&` で「あるときだけ貼る」ことで、**今は空スロット・将来 `mcp.json` を置けば自動で symlink**（install.sh の再変更不要）を1行で両立。

## 検証
- `bash -n` OK、`shellcheck` は既存の SC1091(info) のみ（本変更は指摘なし）
- ロジック検証：中身なし→空フォルダ・dangling なし／中身あり→symlink 解決

🤖 Generated with [Claude Code](https://claude.com/claude-code)