### PR TITLE
fix(zsh): replace is-docker with is-container to detect Apple container

### DIFF
--- a/config/zsh/conf.d/00-core.zsh
+++ b/config/zsh/conf.d/00-core.zsh
@@ -24,7 +24,7 @@ local cyan=$'\e[36m' reset=$'\e[m'
 # the script never stops, even if the locale is misconfigured or
 # unsupported (e.g. LANG set to a locale that is not installed).
 OS_ICON=""
-if is-docker; then
+if is-container; then
   OS_ICON=$(printf '\uF308' 2>/dev/null) || true
 elif is-darwin; then
   OS_ICON=$(printf '\uF179' 2>/dev/null) || true

--- a/config/zsh/conf.d/05-platform.zsh
+++ b/config/zsh/conf.d/05-platform.zsh
@@ -82,7 +82,7 @@ fi
 #
 # Docker
 #
-if is-docker; then
+if is-container; then
   # This setting preserves the history even after restarting the Docker container.
   # https://github.com/uraitakahito/claude-code-docker/blob/0224b6a1c03bc3f47ebff7bcd23ab23da8a9f23c/Dockerfile#L32-L51
   if [ -d /zsh-volume ]; then

--- a/config/zsh/functions/helper.zsh
+++ b/config/zsh/functions/helper.zsh
@@ -32,9 +32,9 @@ function is-darwin {
   [[ "$OSTYPE" == darwin* ]]
 }
 
-# Checks if running in a container.
-function is-docker {
-  [[ -e /.dockerenv ]]
+# Checks if running inside a container (Docker / Podman / Apple container / …).
+function is-container {
+  [[ -e /.dockerenv ]] || [[ -e /run/.containerenv ]] || [[ -e /.cz-init ]] || [[ -n ${container:-} ]]
 }
 
 # Checks if running on Visual Studio Code Terminal.

--- a/install.sh
+++ b/install.sh
@@ -89,7 +89,7 @@ ln -fsn "$SCRIPT_DIR/config/git/template" ~/.config/git/template
 #
 # VS Code
 #
-if is-docker; then
+if is-container; then
   mkdir -p ~/.vscode-server/data/Machine
   ln -fs "$SCRIPT_DIR/config/Code/User/settings.json" ~/.vscode-server/data/Machine/settings.json
   ln -fs "$SCRIPT_DIR/config/Code/User/mcp.json" ~/.vscode-server/data/Machine/mcp.json
@@ -181,7 +181,7 @@ ln -fs "$SCRIPT_DIR/config/gemini/settings.json" ~/.config/gemini/settings.json
 # only exists on the host. In a Docker container (DooD via socket mount), this
 # config would break `docker version` etc. with "context not found".
 #
-if is-darwin && ! is-docker; then
+if is-darwin && ! is-container; then
   mkdir -p ~/.docker
   ln -fs "$SCRIPT_DIR/config/docker/config.json" ~/.docker/config.json
 fi


### PR DESCRIPTION
## 変更内容

`is-docker` を `is-container` に置き換え、コンテナ検出をランタイム非依存に拡張。

- 旧 `is-docker() { [[ -e /.dockerenv ]] }` は **Docker 専用マーカー**しか見ておらず、Apple `container`（マーカー `/.cz-init`）を検出できなかった。
- そのため `HISTFILE` の `/zsh-volume` 切替が効かず、**Apple container で zsh 履歴が再起動で消えていた**。
- `is-container` は複数マーカーの OR：`/.dockerenv`(Docker) / `/run/.containerenv`(Podman) / `/.cz-init`(Apple container) / `$container`(systemd-nspawn 等)。

## 影響箇所（is-docker → is-container、5 参照）

| ファイル | 用途 |
|---|---|
| `config/zsh/functions/helper.zsh` | 関数定義（改名＋検出拡張） |
| `config/zsh/conf.d/05-platform.zsh` | `HISTFILE` を `/zsh-volume` へ（★履歴バグ本体） |
| `config/zsh/conf.d/00-core.zsh` | プロンプトの OS アイコン |
| `install.sh` (×2) | VS Code Server 設定の配置 ／ ホスト限定 `docker/config.json` link |

## 非退行

- ホスト Mac：全マーカー不成立 → `is-container`=false のまま。docker config・アイコン・HISTFILE すべて従来通り。
- Docker：`/.dockerenv` で true のまま（同一 helper を共有）。
- `zsh -n` / `bash -n` 構文チェック済み、`is-container` は bash・zsh 両対応。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
