### PR TITLE
chore(vscode): move sendElementsToChat.attachImages to workbench.browser namespace

### DIFF
--- a/config/Code/User/settings.json
+++ b/config/Code/User/settings.json
@@ -211,9 +211,6 @@
     // Include CSS styles when sending elements to chat
     "chat.sendElementsToChat.attachCSS": true,
 
-    // Include screenshots when sending elements to chat
-    "chat.sendElementsToChat.attachImages": true,
-
     // Use the integrated browser for Live Preview
     "livePreview.useIntegratedBrowser": true,
 
@@ -229,5 +226,10 @@
 
     // -x: follow `source` directives so SC1091 disappears when paired with
     //     a `# shellcheck source=path` hint at the source line.
-    "shellcheck.customArgs": ["-x"]
+    "shellcheck.customArgs": [
+        "-x"
+    ],
+
+    // Include screenshots when sending elements to chat
+    "workbench.browser.sendElementsToChat.attachImages": true
 }


### PR DESCRIPTION
## 変更内容

VS Code の統合ブラウザ（Integrated Browser）設定を整理。

- 「選択した要素を Copilot Chat に送る際に**スクリーンショットを添付する**」トグルのキーを、他の統合ブラウザ設定（すべて `workbench.browser.*`）に合わせて移動：
  - `chat.sendElementsToChat.attachImages` → `workbench.browser.sendElementsToChat.attachImages`（値 `true` は不変）
- `shellcheck.customArgs` を単一行 `["-x"]` → 複数行配列へ整形（体裁のみ・引数不変）

## 注意（記録として）

現行の公式ドキュメントはまだ旧キー `chat.sendElementsToChat.attachImages` 表記のため、VS Code のバージョンによっては新キーが「Unknown Configuration Setting」として無視される可能性あり（設定エディタでホバー確認推奨）。なおこの機能は Simple Browser で既定 ON のため、挙動そのものは既定で有効。`attachCSS` は旧名 `chat.sendElementsToChat.attachCSS` のまま（改名が正なら将来揃える余地あり）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
